### PR TITLE
MVC_SPEC-59 Added support for new ValidationError API

### DIFF
--- a/ozark/pom.xml
+++ b/ozark/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>javax.mvc</groupId>
             <artifactId>javax.mvc-api</artifactId>
-            <version>1.0-edr2</version>
+            <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultImpl.java
@@ -42,11 +42,13 @@ package org.glassfish.ozark.binding;
 import javax.enterprise.context.RequestScoped;
 import javax.mvc.binding.BindingError;
 import javax.mvc.binding.BindingResult;
-import javax.validation.ConstraintViolation;
+import javax.mvc.binding.ValidationError;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation for {@link javax.mvc.binding.BindingResult} interface.
@@ -58,18 +60,18 @@ public class BindingResultImpl implements BindingResult {
 
     private Set<BindingError> errors = Collections.emptySet();
 
-    private Set<ConstraintViolation<?>> violations = Collections.emptySet();
+    private Set<ValidationError> validationErrors = Collections.emptySet();
 
     @Override
     public boolean isFailed() {
-        return violations.size() > 0 || errors.size() > 0;
+        return validationErrors.size() > 0 || errors.size() > 0;
     }
 
     @Override
     public List<String> getAllMessages() {
         final List<String> result = new ArrayList<>();
         errors.forEach(error -> result.add(error.getMessage()));
-        violations.forEach(violation -> result.add(violation.getMessage()));
+        validationErrors.forEach(violation -> result.add(violation.getMessage()));
         return result;
     }
 
@@ -89,22 +91,26 @@ public class BindingResultImpl implements BindingResult {
     }
 
     @Override
-    public Set<ConstraintViolation<?>> getAllViolations() {
-        return violations;
+    public Set<ValidationError> getAllValidationErrors() {
+        return Collections.unmodifiableSet(validationErrors);
     }
 
     @Override
-    public Set<ConstraintViolation<?>> getViolations(String propertyPath) {
-        throw new UnsupportedOperationException("Not supported");
+    public Set<ValidationError> getValidationErrors(String param) {
+        return validationErrors.stream()
+                .filter(ve -> Objects.equals(ve.getParamName(), param))
+                .collect(Collectors.toSet());
     }
 
     @Override
-    public ConstraintViolation<?> getViolation(String propertyPath) {
-        throw new UnsupportedOperationException("Not supported");
+    public ValidationError getValidationError(String param) {
+        return validationErrors.stream()
+                .filter(ve -> Objects.equals(ve.getParamName(), param))
+                .findFirst().orElse(null);
     }
 
-    public void setViolations(Set<ConstraintViolation<?>> violations) {
-        this.violations = violations;
+    public void setValidationErrors(Set<ValidationError> validationErrors) {
+        this.validationErrors = validationErrors;
     }
 
     public void setErrors(Set<BindingError> errors) {

--- a/ozark/src/main/java/org/glassfish/ozark/binding/ConstraintViolationUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/ConstraintViolationUtils.java
@@ -1,0 +1,159 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.binding;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ElementKind;
+import javax.validation.Path;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.MatrixParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for working with {@link ConstraintViolation}.
+ *
+ * @author Christian Kaltepoth
+ */
+public class ConstraintViolationUtils {
+
+    /**
+     * Returns the parameter name to which a {@link ConstraintViolation} refers.
+     */
+    public static String getParamName(ConstraintViolation<?> violation) {
+
+        // create a simple list of nodes from the path
+        List<Path.Node> nodes = new ArrayList<>();
+        for (Path.Node node : violation.getPropertyPath()) {
+            nodes.add(node);
+        }
+        Path.Node lastNode = nodes.get(nodes.size() - 1);
+
+        // the path refers to some property of the leaf bean
+        if (lastNode.getKind() == ElementKind.PROPERTY) {
+
+            Path.PropertyNode propertyNode = lastNode.as(Path.PropertyNode.class);
+            Annotation[] annotations = getPropertyAnnotations(violation, propertyNode);
+
+            return getBeanNameFromAnnotation(annotations);
+
+        }
+
+        // The path refers to a method parameter
+        else if (lastNode.getKind() == ElementKind.PARAMETER && nodes.size() == 2) {
+
+            Path.MethodNode methodNode = nodes.get(0).as(Path.MethodNode.class);
+            Path.ParameterNode parameterNode = nodes.get(1).as(Path.ParameterNode.class);
+
+            Annotation[] annotations = getParameterAnnotations(violation, methodNode, parameterNode);
+
+            return getBeanNameFromAnnotation(annotations);
+
+        }
+
+        return null;
+
+    }
+
+    private static Annotation[] getPropertyAnnotations(ConstraintViolation<?> violation, Path.PropertyNode node) {
+
+        try {
+
+            Class<?> leafBeanClass = violation.getLeafBean().getClass();
+            Field field = leafBeanClass.getDeclaredField(node.getName());
+
+            return field.getAnnotations();
+
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        }
+
+    }
+
+    private static Annotation[] getParameterAnnotations(ConstraintViolation<?> violation, Path.MethodNode methodNode,
+                                                        Path.ParameterNode parameterNode) {
+
+        try {
+
+            String methodName = methodNode.getName();
+
+            int paramCount = methodNode.getParameterTypes().size();
+            Class[] paramTypes = methodNode.getParameterTypes().toArray(new Class[paramCount]);
+
+            Class<?> rootBeanClass = violation.getRootBean().getClass();
+            Method method = rootBeanClass.getMethod(methodName, paramTypes);
+
+            int parameterIndex = parameterNode.getParameterIndex();
+            return method.getParameterAnnotations()[parameterIndex];
+
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+
+    }
+
+    private static String getBeanNameFromAnnotation(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation instanceof QueryParam) {
+                return ((QueryParam) annotation).value();
+            }
+            if (annotation instanceof PathParam) {
+                return ((PathParam) annotation).value();
+            }
+            if (annotation instanceof FormParam) {
+                return ((FormParam) annotation).value();
+            }
+            if (annotation instanceof MatrixParam) {
+                return ((MatrixParam) annotation).value();
+            }
+            if (annotation instanceof CookieParam) {
+                return ((CookieParam) annotation).value();
+            }
+        }
+        return null;
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/binding/ValidationErrorImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/ValidationErrorImpl.java
@@ -37,51 +37,39 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.test.validation;
+package org.glassfish.ozark.binding;
 
-import javax.inject.Inject;
-import javax.mvc.annotation.Controller;
-import javax.mvc.binding.BindingResult;
+import javax.mvc.binding.ValidationError;
 import javax.validation.ConstraintViolation;
-import javax.validation.Valid;
-import javax.validation.executable.ExecutableType;
-import javax.validation.executable.ValidateOnExecution;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
-import java.util.Set;
-
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.OK;
 
 /**
- * FormController class. Defines ValidationResult as a property inherited
- * from a base class.
+ * Implementation of the {@link ValidationError} interface.
  *
- * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  */
-@Controller
-@Path("formprop")
-@Produces("text/html")
-public class FormControllerProperty extends FormControllerBase {
+public class ValidationErrorImpl implements ValidationError {
 
-    @Inject
-    private ErrorDataBean error;
+    private final ConstraintViolation<?> violation;
+    private final String param;
 
-    @POST
-    @ValidateOnExecution(type = ExecutableType.NONE)
-    public Response formPost(@Valid @BeanParam FormDataBean form) {
-        final BindingResult vr = getVr();
-        if (vr.isFailed()) {
-            final ConstraintViolation<?> cv = vr.getAllValidationErrors().iterator().next().getViolation();
-            final String property = cv.getPropertyPath().toString();
-            error.setProperty(property.substring(property.lastIndexOf('.') + 1));
-            error.setValue(cv.getInvalidValue());
-            error.setMessage(cv.getMessage());
-            return Response.status(BAD_REQUEST).entity("error.jsp").build();
-        }
-        return Response.status(OK).entity("data.jsp").build();
+    public ValidationErrorImpl(ConstraintViolation<?> violation, String param) {
+        this.violation = violation;
+        this.param = param;
     }
+
+    @Override
+    public String getParamName() {
+        return param;
+    }
+
+    @Override
+    public ConstraintViolation<?> getViolation() {
+        return violation;
+    }
+
+    @Override
+    public String getMessage() {
+        return violation.getMessage();
+    }
+
 }

--- a/ozark/src/test/java/org/glassfish/ozark/binding/ConstraintViolationUtilsTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/binding/ConstraintViolationUtilsTest.java
@@ -1,0 +1,194 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.binding;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.mvc.annotation.Controller;
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Min;
+import javax.validation.executable.ExecutableValidator;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConstraintViolationUtilsTest {
+
+    private static final long VALID = 10;
+    private static final long INVALID = -10;
+
+    @Test
+    public void shouldSupportControllerFields() {
+
+        SomeController controller = new SomeController();
+        controller.setControllerField(INVALID);
+
+        long methodParameter = VALID;
+
+        BeanParamBean paramBean = new BeanParamBean();
+        paramBean.setBeanParamField(VALID);
+
+        List<ConstraintViolation<?>> violations = simulateValidation(
+                controller, "someControllerMethod", methodParameter, paramBean);
+
+        Assert.assertEquals(1, violations.size());
+        Assert.assertEquals("controller-field",
+                ConstraintViolationUtils.getParamName(violations.get(0)));
+
+    }
+
+    @Test
+    public void shouldSupportMethodParameters() {
+
+        SomeController controller = new SomeController();
+        controller.setControllerField(VALID);
+
+        long methodParameter = INVALID;
+
+        BeanParamBean paramBean = new BeanParamBean();
+        paramBean.setBeanParamField(VALID);
+
+        List<ConstraintViolation<?>> violations = simulateValidation(
+                controller, "someControllerMethod", methodParameter, paramBean);
+
+        Assert.assertEquals(1, violations.size());
+        Assert.assertEquals("method-parameter",
+                ConstraintViolationUtils.getParamName(violations.get(0)));
+
+    }
+
+
+    @Test
+    public void shouldSupportBeanParamBeans() {
+
+        SomeController controller = new SomeController();
+        controller.setControllerField(VALID);
+
+        long methodParameter = VALID;
+
+        BeanParamBean paramBean = new BeanParamBean();
+        paramBean.setBeanParamField(INVALID);
+
+        List<ConstraintViolation<?>> violations = simulateValidation(
+                controller, "someControllerMethod", methodParameter, paramBean);
+
+        Assert.assertEquals(1, violations.size());
+        Assert.assertEquals("bean-param-field",
+                ConstraintViolationUtils.getParamName(violations.get(0)));
+
+    }
+
+    private List<ConstraintViolation<?>> simulateValidation(Object controller, String methodName, Object... args) {
+
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+
+        Validator validator = validatorFactory.getValidator();
+        ExecutableValidator executableValidator = validator.forExecutables();
+
+        List<ConstraintViolation<?>> result = new ArrayList<>();
+
+        // validate controller fields
+        result.addAll(validator.validate(controller));
+
+        // controller method parameters
+        Method method = getFirstMethod(controller.getClass(), methodName);
+        result.addAll(executableValidator.validateParameters(controller, method, args));
+
+        return result;
+
+    }
+
+    private Method getFirstMethod(Class<?> clazz, String methodName) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                return method;
+            }
+        }
+        throw new IllegalStateException("Canot find method: " + methodName);
+    }
+
+    @Controller
+    @Path("something")
+    public static class SomeController {
+
+        @QueryParam("controller-field")
+        @Min(0)
+        private Long controllerField;
+
+        @POST
+        public String someControllerMethod(
+                @FormParam("method-parameter") @Min(0) Long methodParameter,
+                @BeanParam @Valid BeanParamBean beanParam) {
+            return "view.jsp";
+        }
+
+        public void setControllerField(Long controllerField) {
+            this.controllerField = controllerField;
+        }
+
+    }
+
+    public static class BeanParamBean {
+
+        @FormParam("bean-param-field")
+        @Min(0)
+        private long beanParamField;
+
+        public long getBeanParamField() {
+            return beanParamField;
+        }
+
+        public void setBeanParamField(long beanParamField) {
+            this.beanParamField = beanParamField;
+        }
+    }
+
+
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -86,7 +86,7 @@
                 <dependency>
                     <groupId>javax.mvc</groupId>
                     <artifactId>javax.mvc-api</artifactId>
-                    <version>1.0-edr2</version>
+                    <version>1.0-SNAPSHOT</version>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>

--- a/test/validation/src/main/java/org/glassfish/ozark/test/validation/ErrorDataBean.java
+++ b/test/validation/src/main/java/org/glassfish/ozark/test/validation/ErrorDataBean.java
@@ -57,6 +57,8 @@ public class ErrorDataBean {
 
     private String message;
 
+    private String param;
+
     public String getProperty() {
         return property;
     }
@@ -79,5 +81,13 @@ public class ErrorDataBean {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getParam() {
+        return param;
+    }
+
+    public void setParam(String param) {
+        this.param = param;
     }
 }

--- a/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormController.java
+++ b/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormController.java
@@ -44,6 +44,7 @@ import javax.inject.Inject;
 import javax.mvc.annotation.Controller;
 import javax.mvc.binding.BindingError;
 import javax.mvc.binding.BindingResult;
+import javax.mvc.binding.ValidationError;
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.executable.ExecutableType;
@@ -56,7 +57,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import java.util.Set;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -82,11 +82,13 @@ public class FormController {
     @ValidateOnExecution(type = ExecutableType.NONE)
     public Response formPost(@Valid @BeanParam FormDataBean form) {
         if (br.isFailed()) {
-            final ConstraintViolation<?> cv = br.getAllValidationErrors().iterator().next().getViolation();
+            ValidationError validationError = br.getAllValidationErrors().iterator().next();
+            final ConstraintViolation<?> cv = validationError.getViolation();
             final String property = cv.getPropertyPath().toString();
             error.setProperty(property.substring(property.lastIndexOf('.') + 1));
             error.setValue(cv.getInvalidValue());
             error.setMessage(cv.getMessage());
+            error.setParam(validationError.getParamName());
             return Response.status(BAD_REQUEST).entity("error.jsp").build();
         }
         return Response.status(OK).entity("data.jsp").build();

--- a/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormController.java
+++ b/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormController.java
@@ -82,8 +82,7 @@ public class FormController {
     @ValidateOnExecution(type = ExecutableType.NONE)
     public Response formPost(@Valid @BeanParam FormDataBean form) {
         if (br.isFailed()) {
-            final Set<ConstraintViolation<?>> set = br.getAllViolations();
-            final ConstraintViolation<?> cv = set.iterator().next();
+            final ConstraintViolation<?> cv = br.getAllValidationErrors().iterator().next().getViolation();
             final String property = cv.getPropertyPath().toString();
             error.setProperty(property.substring(property.lastIndexOf('.') + 1));
             error.setValue(cv.getInvalidValue());

--- a/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormControllerProperty.java
+++ b/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormControllerProperty.java
@@ -42,6 +42,7 @@ package org.glassfish.ozark.test.validation;
 import javax.inject.Inject;
 import javax.mvc.annotation.Controller;
 import javax.mvc.binding.BindingResult;
+import javax.mvc.binding.ValidationError;
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.executable.ExecutableType;
@@ -51,7 +52,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-import java.util.Set;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -75,11 +75,13 @@ public class FormControllerProperty extends FormControllerBase {
     public Response formPost(@Valid @BeanParam FormDataBean form) {
         final BindingResult vr = getVr();
         if (vr.isFailed()) {
-            final ConstraintViolation<?> cv = vr.getAllValidationErrors().iterator().next().getViolation();
+            ValidationError validationError = vr.getAllValidationErrors().iterator().next();
+            final ConstraintViolation<?> cv = validationError.getViolation();
             final String property = cv.getPropertyPath().toString();
             error.setProperty(property.substring(property.lastIndexOf('.') + 1));
             error.setValue(cv.getInvalidValue());
             error.setMessage(cv.getMessage());
+            error.setParam(validationError.getParamName());
             return Response.status(BAD_REQUEST).entity("error.jsp").build();
         }
         return Response.status(OK).entity("data.jsp").build();

--- a/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
@@ -6,6 +6,7 @@
 </head>
 <body>
     <h1>Binding Error</h1>
-    <p>Param: ${error.property}</p>
+    <p>Property: ${error.property}</p>
+    <p>Param: ${error.param}</p>
     <p>Message: ${error.message}</p>
 </html>

--- a/test/validation/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/error.jsp
@@ -7,6 +7,7 @@
 <body>
     <h1>Form Error</h1>
     <p>Property: ${error.property}</p>
+    <p>Param: ${error.param}</p>
     <p>Value: ${error.value}</p>
     <p>Message: ${error.message}</p>
 </html>

--- a/test/validation/src/test/java/org/glassfish/ozark/test/validation/ValidationIT.java
+++ b/test/validation/src/test/java/org/glassfish/ozark/test/validation/ValidationIT.java
@@ -98,6 +98,7 @@ public class ValidationIT {
         } catch (FailingHttpStatusCodeException e) {
             assertTrue(e.getStatusCode() == 400);
             assertTrue(e.getResponse().getContentAsString().contains("<h1>Form Error</h1>"));
+            assertTrue(e.getResponse().getContentAsString().contains("<p>Param: age</p>"));
         }
     }
 
@@ -131,6 +132,7 @@ public class ValidationIT {
         } catch (FailingHttpStatusCodeException e) {
             assertTrue(e.getStatusCode() == 400);
             assertTrue(e.getResponse().getContentAsString().contains("<h1>Form Error</h1>"));
+            assertTrue(e.getResponse().getContentAsString().contains("<p>Param: age</p>"));
         }
     }
 


### PR DESCRIPTION
This PR contains the required changes for Ozark to support the new `ValidationError` interface and the modified `BindingResult`.

Please note the current version of the implementation doesn't yet set the parameter name correctly. This has to be done in a later step. But IMO that's ok for now as currently Ozark also doesn't know about the parameter name and therefore even doesn't implement `BindingResult.getViolation(String)` at all.