### PR TITLE
Remove Servlet dependencies from VievEngineContext

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# Configuration file for EditorConfig: http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{txt,md}]
+trim_trailing_whitespace = false
+
+[*.properties]
+charset = latin1
+
+[*.yml]
+indent_size = 2
+indent_style = space
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+jdk: oraclejdk8
+install:
+  - mvn dependency:get -Dartifact=javax.mvc:javax.mvc-api:1.0-SNAPSHOT -DremoteRepositories=central::default::https://repo1.maven.org/maven2,javanet::default::https://maven.java.net/content/repositories/snapshots
+  - curl -s -o glassfish41.zip http://download.oracle.com/glassfish/4.1/nightly/glassfish-4.1-web-b17-09_16_2015.zip
+  - unzip -q glassfish41.zip
+script:
+  - mvn clean install -B -V
+  - find ./test/ -name \*.war -exec cp {} ./glassfish4/glassfish/domains/domain1/autodeploy/ \;
+  - glassfish4/bin/asadmin start-domain
+  - sleep 120
+  - mvn -Pintegration -Dintegration.serverPort=8080 verify
+  - glassfish4/bin/asadmin stop-domain
+  - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ script:
   - mvn -Pintegration -Dintegration.serverPort=8080 verify
   - glassfish4/bin/asadmin stop-domain
   - sleep 10
+after_success:
+  - python <(curl -s https://raw.githubusercontent.com/TouK/sputnik-ci/master/sputnik-ci.py)

--- a/ext/asciidoc/src/main/java/org/glassfish/ozark/ext/asciidoc/AsciiDocViewEngine.java
+++ b/ext/asciidoc/src/main/java/org/glassfish/ozark/ext/asciidoc/AsciiDocViewEngine.java
@@ -45,7 +45,6 @@ import org.asciidoctor.Asciidoctor.Factory;
 import org.asciidoctor.Options;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
@@ -55,6 +54,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.HashMap;
+import javax.inject.Inject;
 
 /**
  * Class AsciiDocViewEngine.
@@ -80,7 +80,7 @@ public class AsciiDocViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
-        try (PrintWriter writer = context.getResponse().getWriter();
+        try (PrintWriter writer = context.getWriter();
              InputStream is = servletContext.getResourceAsStream(resolveView(context));
              InputStreamReader isr = new InputStreamReader(is, "UTF-8");
              BufferedReader reader = new BufferedReader(isr)) {

--- a/ext/freemarker/src/main/java/org/glassfish/ozark/ext/freemarker/FreemarkerViewEngine.java
+++ b/ext/freemarker/src/main/java/org/glassfish/ozark/ext/freemarker/FreemarkerViewEngine.java
@@ -56,6 +56,7 @@ import java.io.OutputStreamWriter;
  * Class FreemarkerViewEngine.
  *
  * @author Santiago Pericas-Geertsen
+ * @author Ivar Grimstad
  */
 @ApplicationScoped
 public class FreemarkerViewEngine extends ViewEngineBase {
@@ -74,7 +75,7 @@ public class FreemarkerViewEngine extends ViewEngineBase {
         try {
             final Template template = configuration.getTemplate(resolveView(context));
             template.process(context.getModels(),
-                    new OutputStreamWriter(context.getResponse().getOutputStream()));
+                    new OutputStreamWriter(context.getOutputStream()));
         } catch (TemplateException | IOException e) {
             throw new ViewEngineException(e);
         }

--- a/ext/handlebars/src/main/java/org/glassfish/ozark/ext/handlebars/HandlebarsViewEngine.java
+++ b/ext/handlebars/src/main/java/org/glassfish/ozark/ext/handlebars/HandlebarsViewEngine.java
@@ -57,6 +57,7 @@ import java.util.stream.Collectors;
  * Class HandlebarsViewEngine
  *
  * @author Rahman Usta
+ * @author Ivar Grimstad
  */
 @ApplicationScoped
 public class HandlebarsViewEngine extends ViewEngineBase {
@@ -78,7 +79,7 @@ public class HandlebarsViewEngine extends ViewEngineBase {
         Models models = context.getModels();
         String viewName = context.getView();
 
-        try (PrintWriter writer = context.getResponse().getWriter();
+        try (PrintWriter writer = context.getWriter();
             InputStream resourceAsStream = servletContext.getResourceAsStream(resolveView(context));
             InputStreamReader in = new InputStreamReader(resourceAsStream, "UTF-8");
             BufferedReader bufferedReader = new BufferedReader(in);) {

--- a/ext/jade/src/main/java/org/glassfish/ozark/ext/jade/JadeViewEngine.java
+++ b/ext/jade/src/main/java/org/glassfish/ozark/ext/jade/JadeViewEngine.java
@@ -54,6 +54,7 @@ import java.io.IOException;
  * The Jade View Engine.
  *
  * @author Florian Hirsch
+ * @author Ivar Grimstad
  * @see <a href="http://jade-lang.com/">Jade</a>
  * @see <a href="https://github.com/neuland/jade4j">Jade4J</a>
  */
@@ -73,7 +74,7 @@ public class JadeViewEngine extends ViewEngineBase {
     public void processView(ViewEngineContext context) throws ViewEngineException {
         String viewPath = resolveView(context);
         try {
-            jade.renderTemplate(jade.getTemplate(viewPath), context.getModels(), context.getResponse().getWriter());
+            jade.renderTemplate(jade.getTemplate(viewPath), context.getModels(), context.getWriter());
         } catch (JadeException | IOException ex) {
             throw new ViewEngineException(String.format("Could not process view %s.", context.getView()), ex);
         }

--- a/ext/jsr223/src/main/java/org/glassfish/ozark/ext/jsr223/Jsr223ViewEngine.java
+++ b/ext/jsr223/src/main/java/org/glassfish/ozark/ext/jsr223/Jsr223ViewEngine.java
@@ -44,20 +44,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+import javax.servlet.ServletContext;
 
 /**
  * The JSR-223 ViewEngine.
  *
  * @author Manfred Riem (manfred.riem@oracle.com)
+ * @author Ivar Grimstad
  */
 @ApplicationScoped
 public class Jsr223ViewEngine extends ViewEngineBase {
+
+    @Inject
+    private ServletContext servletContext;
 
     /**
      * Stores our global ScriptEngineManager.
@@ -74,10 +80,10 @@ public class Jsr223ViewEngine extends ViewEngineBase {
     public boolean supports(String view) {
         return getScriptEngine(view) != null;
     }
-    
+
     /**
      * Get the script engine by extension.
-     * 
+     *
      * @param view the view.
      * @return the script engine, or null if not found.
      */
@@ -101,8 +107,7 @@ public class Jsr223ViewEngine extends ViewEngineBase {
         ScriptEngine scriptEngine = getScriptEngine(context.getView());
         Object responseObject;
         try {
-            InputStream inputStream = context.getRequest()
-                    .getServletContext().getResourceAsStream(resolveView(context));
+            InputStream inputStream = servletContext.getResourceAsStream(resolveView(context));
             InputStreamReader reader = new InputStreamReader(inputStream);
             Bindings bindings = scriptEngine.createBindings();
             bindings.put("models", context.getModels());
@@ -112,7 +117,7 @@ public class Jsr223ViewEngine extends ViewEngineBase {
         }
 
         try {
-            context.getResponse().getWriter().print(responseObject.toString());
+            context.getWriter().print(responseObject.toString());
         } catch (IOException exception) {
             throw new ViewEngineException("Unable to write response", exception);
         }

--- a/ext/mustache/src/main/java/org/glassfish/ozark/ext/mustache/MustacheViewEngine.java
+++ b/ext/mustache/src/main/java/org/glassfish/ozark/ext/mustache/MustacheViewEngine.java
@@ -55,6 +55,7 @@ import java.io.Writer;
  * Class MustacheViewEngine.
  *
  * @author Rodrigo Turini
+ * @author Ivar Grimstad
  */
 @ApplicationScoped
 public class MustacheViewEngine extends ViewEngineBase {
@@ -72,7 +73,7 @@ public class MustacheViewEngine extends ViewEngineBase {
     public void processView(ViewEngineContext context) throws ViewEngineException {
         Mustache mustache = factory.compile(resolveView(context));
         try {
-            Writer writer = context.getResponse().getWriter();
+            Writer writer = context.getWriter();
             mustache.execute(writer, context.getModels()).flush();
         } catch (IOException e) {
             throw new ViewEngineException(e);

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>javax.mvc</groupId>
             <artifactId>javax.mvc-api</artifactId>
-            <version>1.0-edr2</version>
+            <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/ext/stringtemplate/src/main/java/org/glassfish/ozark/ext/stringtemplate/StringTemplateViewEngine.java
+++ b/ext/stringtemplate/src/main/java/org/glassfish/ozark/ext/stringtemplate/StringTemplateViewEngine.java
@@ -55,6 +55,7 @@ import static java.util.regex.Pattern.compile;
  * Class StringTemplateViewEngine.
  *
  * @author Rodrigo Turini
+ * @author Ivar Grimstad
  */
 @ApplicationScoped
 public class StringTemplateViewEngine extends ViewEngineBase {
@@ -72,7 +73,7 @@ public class StringTemplateViewEngine extends ViewEngineBase {
 		ST stringTemplate = getStringTemplate(resolveView(context));
 		context.getModels().forEach((key, value) -> add(key, value, stringTemplate));
 		try {
-			PrintWriter writer = context.getResponse().getWriter();
+			PrintWriter writer = context.getWriter();
 			stringTemplate.write(new AutoIndentWriter(writer));
 			stringTemplate.render();
 		} catch (Exception e) {

--- a/ext/thymeleaf/src/main/java/org/glassfish/ozark/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/glassfish/ozark/ext/thymeleaf/ThymeleafViewEngine.java
@@ -49,40 +49,41 @@ import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.glassfish.ozark.engine.OzarkViewEngineContext;
 
 /**
  * Class Thymeleaf ViewEngine.
  *
  * @author Rodrigo Turini
+ * @author Ivar Grimstad
  */
 @ApplicationScoped
 public class ThymeleafViewEngine extends ViewEngineBase {
 
-	@Inject
-	private ServletContext servletContext;
+    @Inject
+    private ServletContext servletContext;
 
-	@Inject
-	@ViewEngineConfig
-	private TemplateEngine engine;
+    @Inject
+    @ViewEngineConfig
+    private TemplateEngine engine;
 
-	@Override
-	public boolean supports(String view) {
-		return view.endsWith(".html");
-	}
+    @Override
+    public boolean supports(String view) {
+        return view.endsWith(".html");
+    }
 
-	@Override
-	public void processView(ViewEngineContext context) throws ViewEngineException {
-		try {
-			HttpServletRequest request = context.getRequest();
-			HttpServletResponse response = context.getResponse();
-			WebContext ctx = new WebContext(request, response, servletContext, request.getLocale());
-			ctx.setVariables(context.getModels());
-			engine.process(resolveView(context), ctx, response.getWriter());
-		} catch (IOException e) {
-			throw new ViewEngineException(e);
-		}
-	}
+    @Override
+    public void processView(ViewEngineContext context) throws ViewEngineException {
+        try {
+            final OzarkViewEngineContext viewEngineContext = (OzarkViewEngineContext) context;
+            HttpServletResponse response = viewEngineContext.getResponse();
+            WebContext ctx = new WebContext(viewEngineContext.getRequest(), response, servletContext, viewEngineContext.getRequest().getLocale());
+            ctx.setVariables(context.getModels());
+            engine.process(resolveView(context), ctx, response.getWriter());
+        } catch (IOException e) {
+            throw new ViewEngineException(e);
+        }
+    }
 }

--- a/ext/velocity/src/main/java/org/glassfish/ozark/ext/velocity/VelocityViewEngine.java
+++ b/ext/velocity/src/main/java/org/glassfish/ozark/ext/velocity/VelocityViewEngine.java
@@ -55,6 +55,7 @@ import java.io.IOException;
  * Class VelocityViewEngine.
  *
  * @author Rodrigo Turini
+ * @author Ivar Grimstad
  */
 @ApplicationScoped
 public class VelocityViewEngine extends ViewEngineBase {
@@ -73,7 +74,7 @@ public class VelocityViewEngine extends ViewEngineBase {
         try {
             Template template = velocityEngine.getTemplate(resolveView(context));
             VelocityContext velocityContext = new VelocityContext(context.getModels());
-            template.merge(velocityContext, context.getResponse().getWriter());
+            template.merge(velocityContext, context.getWriter());
         } catch (IOException e) {
             throw new ViewEngineException(e);
         }

--- a/ozark/pom.xml
+++ b/ozark/pom.xml
@@ -58,6 +58,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -137,9 +142,39 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jglue.cdi-unit</groupId>
-            <artifactId>cdi-unit</artifactId>
-            <version>3.1.3</version>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-api</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-impl</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.modules</groupId>
+            <artifactId>deltaspike-test-control-module-api</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.modules</groupId>
+            <artifactId>deltaspike-test-control-module-impl</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.cdictrl</groupId>
+            <artifactId>deltaspike-cdictrl-weld</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>2.2.13.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ozark/pom.xml
+++ b/ozark/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>javax.mvc</groupId>
             <artifactId>javax.mvc-api</artifactId>
-            <version>1.0-edr2</version>
+            <version>1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/ozark/src/main/java/org/glassfish/ozark/MvcAppConfig.java
+++ b/ozark/src/main/java/org/glassfish/ozark/MvcAppConfig.java
@@ -39,10 +39,15 @@
  */
 package org.glassfish.ozark;
 
+import org.glassfish.ozark.servlet.OzarkContainerInitializer;
 import org.glassfish.ozark.util.PathUtils;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.ServletContext;
 import javax.ws.rs.core.Configuration;
+import java.util.logging.Logger;
 
 /**
  * This application scoped class holds all the global configuration like the
@@ -52,12 +57,30 @@ import javax.ws.rs.core.Configuration;
 @ApplicationScoped
 public class MvcAppConfig {
 
+    private static final Logger log = Logger.getLogger(MvcAppConfig.class.getName());
+
     private String contextPath;
 
     private String applicationPath;
 
     private Configuration config;
 
+    @Inject
+    private ServletContext servletContext;
+
+    @PostConstruct
+    public void init() {
+
+        Object appPath = servletContext.getAttribute(OzarkContainerInitializer.APP_PATH_CONTEXT_KEY);
+        if (appPath != null) {
+            this.applicationPath = PathUtils.normalizePath(appPath.toString());
+        } else {
+            log.warning("Unable to detect application path. " +
+                    "This means that ${mvc.applicationPath} and ${mvc.basePath} will not work correctly");
+        }
+
+    }
+    
     public String getContextPath() {
         return contextPath;
     }
@@ -68,10 +91,6 @@ public class MvcAppConfig {
 
     public String getApplicationPath() {
         return applicationPath;
-    }
-
-    public void setApplicationPath(String applicationPath) {
-        this.applicationPath = PathUtils.normalizePath(applicationPath);
     }
 
     public Configuration getConfig() {

--- a/ozark/src/main/java/org/glassfish/ozark/MvcAppConfig.java
+++ b/ozark/src/main/java/org/glassfish/ozark/MvcAppConfig.java
@@ -37,42 +37,48 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.servlet;
+package org.glassfish.ozark;
 
-import org.glassfish.ozark.MvcAppConfig;
+import org.glassfish.ozark.util.PathUtils;
 
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HandlesTypes;
-import javax.ws.rs.ApplicationPath;
-import java.util.Set;
-
-import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.CdiUtils.newBean;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.core.Configuration;
 
 /**
- * Initializes the Mvc class with the application and context path. Note that the
- * application path is only initialized if there is an application sub-class that
- * is annotated by {@link javax.ws.rs.ApplicationPath}.
- *
- * @author Santiago Pericas-Geertsen
+ * This application scoped class holds all the global configuration like the
+ * context and application path and is used by {@link MvcContextImpl} to expose
+ * this information to the user.
  */
-@HandlesTypes({ ApplicationPath.class })
-public class OzarkContainerInitializer implements ServletContainerInitializer {
+@ApplicationScoped
+public class MvcAppConfig {
 
-    @Override
-    public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
-        if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final BeanManager bm = CDI.current().getBeanManager();
-            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                appConfig.setApplicationPath(ap.value());
-            }
-        }
+    private String contextPath;
+
+    private String applicationPath;
+
+    private Configuration config;
+
+    public String getContextPath() {
+        return contextPath;
+    }
+
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;     // normalized by servlet
+    }
+
+    public String getApplicationPath() {
+        return applicationPath;
+    }
+
+    public void setApplicationPath(String applicationPath) {
+        this.applicationPath = PathUtils.normalizePath(applicationPath);
+    }
+
+    public Configuration getConfig() {
+        return config;
+    }
+
+    public void setConfig(Configuration config) {
+        this.config = config;
     }
 }

--- a/ozark/src/main/java/org/glassfish/ozark/MvcContextImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/MvcContextImpl.java
@@ -39,7 +39,7 @@
  */
 package org.glassfish.ozark;
 
-import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.mvc.MvcContext;
@@ -47,7 +47,7 @@ import javax.mvc.security.Csrf;
 import javax.mvc.security.Encoders;
 import javax.ws.rs.core.Configuration;
 
-import static org.glassfish.ozark.util.PathUtils.normalizePath;
+import java.util.Locale;
 
 /**
  * Implementation of {@link javax.mvc.MvcContext}.
@@ -55,7 +55,7 @@ import static org.glassfish.ozark.util.PathUtils.normalizePath;
  * @author Santiago Pericas-Geertsen
  */
 @Named("mvc")
-@ApplicationScoped
+@RequestScoped
 public class MvcContextImpl implements MvcContext {
 
     @Inject
@@ -64,33 +64,27 @@ public class MvcContextImpl implements MvcContext {
     @Inject
     private Encoders encoders;
 
-    private String contextPath;
+    @Inject
+    private MvcAppConfig appConfig;
 
-    private String applicationPath;
-
-    private Configuration config;
+    private Locale locale;
 
     @Override
     public String getContextPath() {
-        return contextPath;
-    }
-
-    public void setContextPath(String contextPath) {
-        this.contextPath = contextPath;     // normalized by servlet
+        return appConfig.getContextPath();
     }
 
     @Override
     public String getApplicationPath() {
-        return applicationPath;
-    }
-
-    public void setApplicationPath(String applicationPath) {
-        this.applicationPath = normalizePath(applicationPath);
+        return appConfig.getApplicationPath();
     }
 
     @Override
     public String getBasePath() {
-        return applicationPath == null ? contextPath : contextPath + applicationPath;
+        if (getApplicationPath() != null) {
+            return getContextPath() + getApplicationPath();
+        }
+        return getContextPath();
     }
 
     @Override
@@ -105,10 +99,15 @@ public class MvcContextImpl implements MvcContext {
 
     @Override
     public Configuration getConfig() {
-        return config;
+        return appConfig.getConfig();
     }
 
-    public void setConfig(Configuration config) {
-        this.config = config;
+    @Override
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public void setLocale(Locale locale) {
+        this.locale = locale;
     }
 }

--- a/ozark/src/main/java/org/glassfish/ozark/binding/BindingInterceptorImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/BindingInterceptorImpl.java
@@ -95,10 +95,8 @@ public class BindingInterceptorImpl implements ValidationInterceptor {
         }
 
         // Update binding result or re-throw first exception if not present
-        if (errors.size() > 0) {
-            if (!updateBindingResultErrors(resource, errors, bindingResult)) {
-                throw firstException;
-            }
+        if (errors.size() > 0 && !updateBindingResultErrors(resource, errors, bindingResult)) {
+            throw firstException;
         }
 
         try {

--- a/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultImpl.java
@@ -42,11 +42,13 @@ package org.glassfish.ozark.binding;
 import javax.enterprise.context.RequestScoped;
 import javax.mvc.binding.BindingError;
 import javax.mvc.binding.BindingResult;
-import javax.validation.ConstraintViolation;
+import javax.mvc.binding.ValidationError;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implementation for {@link javax.mvc.binding.BindingResult} interface.
@@ -58,18 +60,18 @@ public class BindingResultImpl implements BindingResult {
 
     private Set<BindingError> errors = Collections.emptySet();
 
-    private Set<ConstraintViolation<?>> violations = Collections.emptySet();
+    private Set<ValidationError> validationErrors = Collections.emptySet();
 
     @Override
     public boolean isFailed() {
-        return violations.size() > 0 || errors.size() > 0;
+        return validationErrors.size() > 0 || errors.size() > 0;
     }
 
     @Override
     public List<String> getAllMessages() {
         final List<String> result = new ArrayList<>();
         errors.forEach(error -> result.add(error.getMessage()));
-        violations.forEach(violation -> result.add(violation.getMessage()));
+        validationErrors.forEach(violation -> result.add(violation.getMessage()));
         return result;
     }
 
@@ -89,22 +91,26 @@ public class BindingResultImpl implements BindingResult {
     }
 
     @Override
-    public Set<ConstraintViolation<?>> getAllViolations() {
-        return violations;
+    public Set<ValidationError> getAllValidationErrors() {
+        return Collections.unmodifiableSet(validationErrors);
     }
 
     @Override
-    public Set<ConstraintViolation<?>> getViolations(String propertyPath) {
-        throw new UnsupportedOperationException("Not supported");
+    public Set<ValidationError> getValidationErrors(String param) {
+        return validationErrors.stream()
+                .filter(ve -> Objects.equals(ve.getParamName(), param))
+                .collect(Collectors.toSet());
     }
 
     @Override
-    public ConstraintViolation<?> getViolation(String propertyPath) {
-        throw new UnsupportedOperationException("Not supported");
+    public ValidationError getValidationError(String param) {
+        return validationErrors.stream()
+                .filter(ve -> Objects.equals(ve.getParamName(), param))
+                .findFirst().orElse(null);
     }
 
-    public void setViolations(Set<ConstraintViolation<?>> violations) {
-        this.violations = violations;
+    public void setValidationErrors(Set<ValidationError> validationErrors) {
+        this.validationErrors = validationErrors;
     }
 
     public void setErrors(Set<BindingError> errors) {

--- a/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
@@ -342,13 +342,12 @@ public final class BindingResultUtils {
      */
     public static Object getValidInstanceForType(Class<?> type) {
         if (type.isPrimitive()) {
-            Class<?> boxed = null;
             if (type == boolean.class) {
-                return new Boolean(true);
+                return Boolean.TRUE;
             } else if (type == char.class) {
-                return new Character(' ');
+                return Character.valueOf(' ');
             } else if (type == byte.class || type == short.class || type == int.class || type == long.class) {
-                return new Byte((byte) 0);
+                return Byte.valueOf((byte) 0);
             } else if (type == double.class || type == float.class) {
                 return new Float(0.0);
             }

--- a/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
@@ -42,13 +42,16 @@ package org.glassfish.ozark.binding;
 import javax.inject.Inject;
 import javax.mvc.binding.BindingError;
 import javax.mvc.binding.BindingResult;
+import javax.mvc.binding.ValidationError;
 import javax.validation.ConstraintViolation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * Helper class to implement support for {@code javax.mvc.binding.BindingResult}.
@@ -58,6 +61,8 @@ import java.util.Set;
  * @author Santiago Pericas-Geertsen
  */
 public final class BindingResultUtils {
+
+    private static final Logger LOG = Logger.getLogger(BindingResultUtils.class.getName());
 
     private static Class<?> TARGET_INSTANCE;
 
@@ -148,9 +153,23 @@ public final class BindingResultUtils {
      */
     public static boolean updateBindingResultViolations(Object resource, Set<ConstraintViolation<?>> violations,
                                                         BindingResultImpl arg) {
+
+        Set<ValidationError> validationErrors = new LinkedHashSet<>();
+
+        for (ConstraintViolation<?> violation : violations) {
+
+            String paramName = ConstraintViolationUtils.getParamName(violation);
+            if (paramName == null) {
+                LOG.warning("Cannot resolve paramName for violation: " + violation);
+            }
+
+            validationErrors.add(new ValidationErrorImpl(violation, paramName));
+
+        }
+
         // Is it in an argument position
         if (arg != null) {
-            arg.setViolations(violations);
+            arg.setValidationErrors(validationErrors);
             return true;
         }
 
@@ -158,7 +177,7 @@ public final class BindingResultUtils {
         try {
             if (hasBindingResultProperty(resource)) {
                 final Object obj = getBindingResultGetter(resource).invoke(resource);
-                getSetterMethod(obj, "setViolations").invoke(obj, violations);
+                getSetterMethod(obj, "setValidationErrors").invoke(obj, validationErrors);
             } else {
                 // Then check for a field
                 final Field vr = getBindingResultField(resource);
@@ -168,7 +187,7 @@ public final class BindingResultUtils {
                         return null;
                     });
                     final BindingResultImpl value = (BindingResultImpl) vr.get(resource);
-                    value.setViolations(violations);
+                    value.setValidationErrors(validationErrors);
                 } else {
                     return false;
                 }

--- a/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
@@ -81,7 +81,7 @@ public final class BindingResultUtils {
      * @param resource resource instance.
      * @return field or {@code null} if none is found.
      */
-    public static Field getBindingResultField(final Object resource) {
+    private static Field getBindingResultField(final Object resource) {
         Class<?> clazz = resource.getClass();
         do {
             for (Field f : clazz.getDeclaredFields()) {
@@ -208,7 +208,7 @@ public final class BindingResultUtils {
      * @param resource resource instance.
      * @return outcome of test.
      */
-    public static boolean hasBindingResultProperty(final Object resource) {
+    private static boolean hasBindingResultProperty(final Object resource) {
         return getBindingResultGetter(resource) != null && getBindingResultSetter(resource) != null;
     }
 
@@ -219,7 +219,7 @@ public final class BindingResultUtils {
      * @param resource resource instance.
      * @return getter or {@code null} if not available.
      */
-    public static Method getBindingResultGetter(final Object resource) {
+    private static Method getBindingResultGetter(final Object resource) {
         Class<?> clazz = resource.getClass();
         do {
             for (Method m : clazz.getDeclaredMethods()) {
@@ -251,7 +251,7 @@ public final class BindingResultUtils {
      * @param resource resource instance.
      * @return setter or {@code null} if not available.
      */
-    public static Method getBindingResultSetter(final Object resource) {
+    private static Method getBindingResultSetter(final Object resource) {
         return getBindingResultSetter(resource.getClass());
     }
 

--- a/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/BindingResultUtils.java
@@ -43,15 +43,12 @@ import javax.inject.Inject;
 import javax.mvc.binding.BindingError;
 import javax.mvc.binding.BindingResult;
 import javax.mvc.binding.ValidationError;
-import javax.validation.ConstraintViolation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.security.AccessController;
-import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.logging.Logger;
 
 /**
  * Helper class to implement support for {@code javax.mvc.binding.BindingResult}.
@@ -61,8 +58,6 @@ import java.util.logging.Logger;
  * @author Santiago Pericas-Geertsen
  */
 public final class BindingResultUtils {
-
-    private static final Logger LOG = Logger.getLogger(BindingResultUtils.class.getName());
 
     private static Class<?> TARGET_INSTANCE;
 
@@ -143,29 +138,16 @@ public final class BindingResultUtils {
     }
 
     /**
-     * Updates the constraint violation set of a {@code javax.mvc.binding.BindingResult}.
+     * Updates the validation error set of a {@code javax.mvc.binding.BindingResult}.
      * First checks for an argument, then a property and finally a field.
      *
-     * @param resource   the resource instance.
-     * @param violations set of constraint violations.
+     * @param resource the resource instance.
+     * @param validationErrors set of validation errors.
      * @param arg argument in invocation or {@code null}.
      * @return {@code true} if arg, property or field updated, or {@code false} otherwise.
      */
-    public static boolean updateBindingResultViolations(Object resource, Set<ConstraintViolation<?>> violations,
+    public static boolean updateBindingResultViolations(Object resource, Set<ValidationError> validationErrors,
                                                         BindingResultImpl arg) {
-
-        Set<ValidationError> validationErrors = new LinkedHashSet<>();
-
-        for (ConstraintViolation<?> violation : violations) {
-
-            String paramName = ConstraintViolationUtils.getParamName(violation);
-            if (paramName == null) {
-                LOG.warning("Cannot resolve paramName for violation: " + violation);
-            }
-
-            validationErrors.add(new ValidationErrorImpl(violation, paramName));
-
-        }
 
         // Is it in an argument position
         if (arg != null) {

--- a/ozark/src/main/java/org/glassfish/ozark/binding/ConstraintViolationTranslator.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/ConstraintViolationTranslator.java
@@ -1,0 +1,145 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.binding;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.MessageInterpolator;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.metadata.ConstraintDescriptor;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+/**
+ * Helper class to get a human readable errors message for a {@link ConstraintViolation}
+ * for a specific target locale.
+ *
+ * @author Christian Kaltepoth
+ */
+@ApplicationScoped
+public class ConstraintViolationTranslator {
+
+    private static final Logger log = Logger.getLogger(ConstraintViolationTranslator.class.getName());
+
+    /**
+     * The ValidatorFactory should be available for injection as defined here:
+     * http://beanvalidation.org/1.1/spec/#d0e11327
+     */
+    @Inject
+    private Instance<ValidatorFactory> validatorFactoryInstance;
+
+    /**
+     * The actual ValidatorFactory to use
+     */
+    private ValidatorFactory validatorFactory;
+
+    /**
+     * We should be able to get a ValidatorFactory from the container in an Java EE environment.
+     * However, if we don't get the factory, we will will use a default one. This is especially
+     * useful for non Java EE environments and in the CDI tests
+     */
+    @PostConstruct
+    public void init() {
+
+        // Prefer the ValidatorFactory provided by the container
+        Iterator<ValidatorFactory> iterator = validatorFactoryInstance.iterator();
+        if (iterator.hasNext()) {
+            this.validatorFactory = iterator.next();
+        }
+
+        // create a default factory if we didn't get one
+        else {
+            log.warning("Creating a ValidatorFactory because the container didn't provide one!");
+            this.validatorFactory = Validation.buildDefaultValidatorFactory();
+        }
+
+    }
+
+    /**
+     * Returns the human readable error message for a given {@link ConstraintViolation}.
+     *
+     * @param violation The violation to get the message for
+     * @param locale    The desired target locale
+     * @return the localized message
+     */
+    public String translate(ConstraintViolation<?> violation, Locale locale) {
+
+        SimpleMessageInterpolatorContext context = new SimpleMessageInterpolatorContext(violation);
+
+        MessageInterpolator interpolator = validatorFactory.getMessageInterpolator();
+
+        return interpolator.interpolate(violation.getMessageTemplate(), context, locale);
+
+    }
+
+    /**
+     * Simple implementation of {@link javax.validation.MessageInterpolator.Context} wrapping
+     * a {@link ConstraintViolation}.
+     */
+    private static class SimpleMessageInterpolatorContext implements MessageInterpolator.Context {
+
+        private final ConstraintViolation<?> violation;
+
+        public SimpleMessageInterpolatorContext(ConstraintViolation<?> violation) {
+            this.violation = violation;
+        }
+
+        @Override
+        public ConstraintDescriptor<?> getConstraintDescriptor() {
+            return violation.getConstraintDescriptor();
+        }
+
+        @Override
+        public Object getValidatedValue() {
+            return violation.getInvalidValue();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> type) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/binding/ConstraintViolationUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/ConstraintViolationUtils.java
@@ -1,0 +1,159 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.binding;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ElementKind;
+import javax.validation.Path;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.MatrixParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for working with {@link ConstraintViolation}.
+ *
+ * @author Christian Kaltepoth
+ */
+public class ConstraintViolationUtils {
+
+    /**
+     * Returns the parameter name to which a {@link ConstraintViolation} refers.
+     */
+    public static String getParamName(ConstraintViolation<?> violation) {
+
+        // create a simple list of nodes from the path
+        List<Path.Node> nodes = new ArrayList<>();
+        for (Path.Node node : violation.getPropertyPath()) {
+            nodes.add(node);
+        }
+        Path.Node lastNode = nodes.get(nodes.size() - 1);
+
+        // the path refers to some property of the leaf bean
+        if (lastNode.getKind() == ElementKind.PROPERTY) {
+
+            Path.PropertyNode propertyNode = lastNode.as(Path.PropertyNode.class);
+            Annotation[] annotations = getPropertyAnnotations(violation, propertyNode);
+
+            return getBeanNameFromAnnotation(annotations);
+
+        }
+
+        // The path refers to a method parameter
+        else if (lastNode.getKind() == ElementKind.PARAMETER && nodes.size() == 2) {
+
+            Path.MethodNode methodNode = nodes.get(0).as(Path.MethodNode.class);
+            Path.ParameterNode parameterNode = nodes.get(1).as(Path.ParameterNode.class);
+
+            Annotation[] annotations = getParameterAnnotations(violation, methodNode, parameterNode);
+
+            return getBeanNameFromAnnotation(annotations);
+
+        }
+
+        return null;
+
+    }
+
+    private static Annotation[] getPropertyAnnotations(ConstraintViolation<?> violation, Path.PropertyNode node) {
+
+        try {
+
+            Class<?> leafBeanClass = violation.getLeafBean().getClass();
+            Field field = leafBeanClass.getDeclaredField(node.getName());
+
+            return field.getAnnotations();
+
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        }
+
+    }
+
+    private static Annotation[] getParameterAnnotations(ConstraintViolation<?> violation, Path.MethodNode methodNode,
+                                                        Path.ParameterNode parameterNode) {
+
+        try {
+
+            String methodName = methodNode.getName();
+
+            int paramCount = methodNode.getParameterTypes().size();
+            Class[] paramTypes = methodNode.getParameterTypes().toArray(new Class[paramCount]);
+
+            Class<?> rootBeanClass = violation.getRootBean().getClass();
+            Method method = rootBeanClass.getMethod(methodName, paramTypes);
+
+            int parameterIndex = parameterNode.getParameterIndex();
+            return method.getParameterAnnotations()[parameterIndex];
+
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException(e);
+        }
+
+    }
+
+    private static String getBeanNameFromAnnotation(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation instanceof QueryParam) {
+                return ((QueryParam) annotation).value();
+            }
+            if (annotation instanceof PathParam) {
+                return ((PathParam) annotation).value();
+            }
+            if (annotation instanceof FormParam) {
+                return ((FormParam) annotation).value();
+            }
+            if (annotation instanceof MatrixParam) {
+                return ((MatrixParam) annotation).value();
+            }
+            if (annotation instanceof CookieParam) {
+                return ((CookieParam) annotation).value();
+            }
+        }
+        return null;
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/binding/ValidationErrorImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/ValidationErrorImpl.java
@@ -37,53 +37,39 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.test.validation;
+package org.glassfish.ozark.binding;
 
-import javax.inject.Inject;
-import javax.mvc.annotation.Controller;
-import javax.mvc.binding.BindingResult;
 import javax.mvc.binding.ValidationError;
 import javax.validation.ConstraintViolation;
-import javax.validation.Valid;
-import javax.validation.executable.ExecutableType;
-import javax.validation.executable.ValidateOnExecution;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
-
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static javax.ws.rs.core.Response.Status.OK;
 
 /**
- * FormController class. Defines ValidationResult as a property inherited
- * from a base class.
+ * Implementation of the {@link ValidationError} interface.
  *
- * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  */
-@Controller
-@Path("formprop")
-@Produces("text/html")
-public class FormControllerProperty extends FormControllerBase {
+public class ValidationErrorImpl implements ValidationError {
 
-    @Inject
-    private ErrorDataBean error;
+    private final ConstraintViolation<?> violation;
+    private final String param;
 
-    @POST
-    @ValidateOnExecution(type = ExecutableType.NONE)
-    public Response formPost(@Valid @BeanParam FormDataBean form) {
-        final BindingResult vr = getVr();
-        if (vr.isFailed()) {
-            ValidationError validationError = vr.getAllValidationErrors().iterator().next();
-            final ConstraintViolation<?> cv = validationError.getViolation();
-            final String property = cv.getPropertyPath().toString();
-            error.setProperty(property.substring(property.lastIndexOf('.') + 1));
-            error.setValue(cv.getInvalidValue());
-            error.setMessage(cv.getMessage());
-            error.setParam(validationError.getParamName());
-            return Response.status(BAD_REQUEST).entity("error.jsp").build();
-        }
-        return Response.status(OK).entity("data.jsp").build();
+    public ValidationErrorImpl(ConstraintViolation<?> violation, String param) {
+        this.violation = violation;
+        this.param = param;
     }
+
+    @Override
+    public String getParamName() {
+        return param;
+    }
+
+    @Override
+    public ConstraintViolation<?> getViolation() {
+        return violation;
+    }
+
+    @Override
+    public String getMessage() {
+        return violation.getMessage();
+    }
+
 }

--- a/ozark/src/main/java/org/glassfish/ozark/binding/ValidationErrorImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/binding/ValidationErrorImpl.java
@@ -51,10 +51,12 @@ public class ValidationErrorImpl implements ValidationError {
 
     private final ConstraintViolation<?> violation;
     private final String param;
+    private final String message;
 
-    public ValidationErrorImpl(ConstraintViolation<?> violation, String param) {
+    public ValidationErrorImpl(ConstraintViolation<?> violation, String param, String message) {
         this.violation = violation;
         this.param = param;
+        this.message = message;
     }
 
     @Override
@@ -69,7 +71,7 @@ public class ValidationErrorImpl implements ValidationError {
 
     @Override
     public String getMessage() {
-        return violation.getMessage();
+        return message;
     }
 
 }

--- a/ozark/src/main/java/org/glassfish/ozark/core/ViewResponseFilter.java
+++ b/ozark/src/main/java/org/glassfish/ozark/core/ViewResponseFilter.java
@@ -62,22 +62,15 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 
-import static javax.ws.rs.core.Response.Status.FOUND;
-import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
-import static javax.ws.rs.core.Response.Status.NO_CONTENT;
-import static javax.ws.rs.core.Response.Status.OK;
-import static javax.ws.rs.core.Response.Status.SEE_OTHER;
-import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
+import static javax.ws.rs.core.Response.Status.*;
 import static org.glassfish.ozark.cdi.OzarkCdiExtension.isEventObserved;
 import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.PathUtils.noPrefix;
-import static org.glassfish.ozark.util.PathUtils.noStartingSlash;
+import static org.glassfish.ozark.util.PathUtils.*;
 
 /**
  * <p>A JAX-RS response filter that fires a {@link javax.mvc.event.AfterControllerEvent}
@@ -154,14 +147,12 @@ public class ViewResponseFilter implements ContainerResponseFilter {
                 // set the status to 200 unless no other status was set by e.g. throwing an Exception.
                 responseContext.setStatusInfo(responseContext.getStatusInfo() == NO_CONTENT ? OK : responseContext.getStatusInfo());
             } else if (returnType == Void.class) {
-                throw new ServerErrorException(messages.get("VoidControllerNoView", resourceInfo.getResourceMethod()),
-                    Response.Status.INTERNAL_SERVER_ERROR);
+                throw new ServerErrorException(messages.get("VoidControllerNoView", resourceInfo.getResourceMethod()), INTERNAL_SERVER_ERROR);
             }
         } else if (entityType != Viewable.class) {
             final String view = entity.toString();
             if (view == null) {
-                throw new ServerErrorException(messages.get("EntityToStringNull", resourceInfo.getResourceMethod()),
-                        Response.Status.INTERNAL_SERVER_ERROR);
+                throw new ServerErrorException(messages.get("EntityToStringNull", resourceInfo.getResourceMethod()), INTERNAL_SERVER_ERROR);
             }
             responseContext.setEntity(new Viewable(view), null, responseContext.getMediaType());
         }

--- a/ozark/src/main/java/org/glassfish/ozark/core/ViewResponseFilter.java
+++ b/ozark/src/main/java/org/glassfish/ozark/core/ViewResponseFilter.java
@@ -70,6 +70,7 @@ import java.net.URI;
 
 import static javax.ws.rs.core.Response.Status.FOUND;
 import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.SEE_OTHER;
 import static javax.ws.rs.core.Response.Status.TEMPORARY_REDIRECT;
@@ -149,7 +150,9 @@ public class ViewResponseFilter implements ContainerResponseFilter {
                     contentType = MediaType.TEXT_HTML_TYPE;     // default
                 }
                 responseContext.setEntity(new Viewable(an.value()), null, contentType);
-                responseContext.setStatusInfo(OK);      // Needed for method returning void
+                // If the entity is null the status will be set to 204 by Jersey. For void methods we need to
+                // set the status to 200 unless no other status was set by e.g. throwing an Exception.
+                responseContext.setStatusInfo(responseContext.getStatusInfo() == NO_CONTENT ? OK : responseContext.getStatusInfo());
             } else if (returnType == Void.class) {
                 throw new ServerErrorException(messages.get("VoidControllerNoView", resourceInfo.getResourceMethod()),
                     Response.Status.INTERNAL_SERVER_ERROR);

--- a/ozark/src/main/java/org/glassfish/ozark/core/ViewableWriter.java
+++ b/ozark/src/main/java/org/glassfish/ozark/core/ViewableWriter.java
@@ -60,6 +60,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 import javax.ws.rs.Produces;
@@ -159,7 +160,15 @@ public class ViewableWriter implements MessageBodyWriter<Viewable> {
                     request.getServletContext().getRequestDispatcher(ensureStartingSlash(viewable.getView()));
             if (requestDispatcher != null) {
                 try {
-                    requestDispatcher.forward(request, response);
+                    /*
+                     * The RequestDispatcher contract requires us to pass in the original request/response
+                     * instances or standard wrapper classes. As we get the request/response via injection,
+                     * we end up with proxies, so we must wrap the proxies in wrapper classes.
+                     */
+                    requestDispatcher.forward(
+                            new HttpServletRequestWrapper(request),
+                            new HttpServletResponseWrapper(response)
+                    );
                 } catch (ServletException ex) {
                     throw new ServerErrorException(INTERNAL_SERVER_ERROR, ex);
                 }

--- a/ozark/src/main/java/org/glassfish/ozark/core/ViewableWriter.java
+++ b/ozark/src/main/java/org/glassfish/ozark/core/ViewableWriter.java
@@ -39,7 +39,7 @@
  */
 package org.glassfish.ozark.core;
 
-import org.glassfish.ozark.engine.ViewEngineContextImpl;
+import org.glassfish.ozark.engine.OzarkViewEngineContext;
 import org.glassfish.ozark.engine.ViewEngineFinder;
 import org.glassfish.ozark.event.AfterProcessViewEventImpl;
 import org.glassfish.ozark.event.BeforeProcessViewEventImpl;
@@ -230,7 +230,7 @@ public class ViewableWriter implements MessageBodyWriter<Viewable> {
             }
 
             // Process view using selected engine
-            engine.processView(new ViewEngineContextImpl(viewable.getView(), models, request, responseWrapper,
+            engine.processView(new OzarkViewEngineContext(viewable.getView(), models, request, responseWrapper,
                     uriInfo, resourceInfo, config));
 
             // Fire AfterProcessView event

--- a/ozark/src/main/java/org/glassfish/ozark/engine/OzarkViewEngineContext.java
+++ b/ozark/src/main/java/org/glassfish/ozark/engine/OzarkViewEngineContext.java
@@ -57,7 +57,7 @@ import javax.ws.rs.core.UriInfo;
  * @author Santiago Pericas-Geertsen
  * @author Ivar Grimstad
  */
-public class ViewEngineContextImpl implements ViewEngineContext {
+public class OzarkViewEngineContext implements ViewEngineContext {
 
     private final String view;
 
@@ -84,7 +84,7 @@ public class ViewEngineContextImpl implements ViewEngineContext {
      * @param resourceInfo Resource matched info.
      * @param configuration the configuration.
      */
-    public ViewEngineContextImpl(String view, Models models, HttpServletRequest request, HttpServletResponse response,
+    public OzarkViewEngineContext(String view, Models models, HttpServletRequest request, HttpServletResponse response,
                                  UriInfo uriInfo, ResourceInfo resourceInfo, Configuration configuration) {
         this.view = view;
         this.models = models;

--- a/ozark/src/main/java/org/glassfish/ozark/engine/ServletViewEngine.java
+++ b/ozark/src/main/java/org/glassfish/ozark/engine/ServletViewEngine.java
@@ -86,8 +86,9 @@ public abstract class ServletViewEngine extends ViewEngineBase {
     protected void forwardRequest(ViewEngineContext context, String... extensions)
             throws ServletException, IOException {
         RequestDispatcher rd = null;
-        HttpServletRequest request = ((ViewEngineContextImpl) context).getRequest();
-        final HttpServletResponse response = ((ViewEngineContextImpl) context).getResponse();
+        final OzarkViewEngineContext viewEngineContext = (OzarkViewEngineContext) context;
+        HttpServletRequest request = viewEngineContext.getRequest();
+        final HttpServletResponse response = viewEngineContext.getResponse();
 
         // Set attributes in request before forward
         final Models models = context.getModels();
@@ -102,7 +103,7 @@ public abstract class ServletViewEngine extends ViewEngineBase {
                 rd = servletContext.getNamedDispatcher(e.getKey());     // by servlet name
 
                 // Need new request with updated URI and extension matching semantics
-                request = new HttpServletRequestWrapper(((ViewEngineContextImpl) context).getRequest()) {
+                request = new HttpServletRequestWrapper(viewEngineContext.getRequest()) {
                     @Override
                     public String getRequestURI() {
                         return resolveView(context);

--- a/ozark/src/main/java/org/glassfish/ozark/engine/ServletViewEngine.java
+++ b/ozark/src/main/java/org/glassfish/ozark/engine/ServletViewEngine.java
@@ -60,6 +60,7 @@ import java.util.Map;
  * first looking at servlets that handle the specified extensions directly.
  *
  * @author Santiago Pericas-Geertsen
+ * @author Ivar Grimstad
  */
 public abstract class ServletViewEngine extends ViewEngineBase {
 
@@ -85,8 +86,8 @@ public abstract class ServletViewEngine extends ViewEngineBase {
     protected void forwardRequest(ViewEngineContext context, String... extensions)
             throws ServletException, IOException {
         RequestDispatcher rd = null;
-        HttpServletRequest request = context.getRequest();
-        final HttpServletResponse response = context.getResponse();
+        HttpServletRequest request = ((ViewEngineContextImpl) context).getRequest();
+        final HttpServletResponse response = ((ViewEngineContextImpl) context).getResponse();
 
         // Set attributes in request before forward
         final Models models = context.getModels();
@@ -101,7 +102,7 @@ public abstract class ServletViewEngine extends ViewEngineBase {
                 rd = servletContext.getNamedDispatcher(e.getKey());     // by servlet name
 
                 // Need new request with updated URI and extension matching semantics
-                request = new HttpServletRequestWrapper(context.getRequest()) {
+                request = new HttpServletRequestWrapper(((ViewEngineContextImpl) context).getRequest()) {
                     @Override
                     public String getRequestURI() {
                         return resolveView(context);

--- a/ozark/src/main/java/org/glassfish/ozark/engine/ViewEngineContextImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/engine/ViewEngineContextImpl.java
@@ -52,6 +52,7 @@ import javax.ws.rs.core.UriInfo;
  * needed for a view engine to process a view.
  *
  * @author Santiago Pericas-Geertsen
+ * @author Ivar Grimstad
  */
 public class ViewEngineContextImpl implements ViewEngineContext {
 
@@ -101,12 +102,10 @@ public class ViewEngineContextImpl implements ViewEngineContext {
         return models;
     }
 
-    @Override
     public HttpServletRequest getRequest() {
         return request;
     }
 
-    @Override
     public HttpServletResponse getResponse() {
         return response;
     }

--- a/ozark/src/main/java/org/glassfish/ozark/engine/ViewEngineContextImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/engine/ViewEngineContextImpl.java
@@ -39,6 +39,9 @@
  */
 package org.glassfish.ozark.engine;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import javax.mvc.Models;
 import javax.mvc.engine.ViewEngineContext;
 import javax.servlet.http.HttpServletRequest;
@@ -123,5 +126,15 @@ public class ViewEngineContextImpl implements ViewEngineContext {
     @Override
     public Configuration getConfiguration() {
         return configuration;
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return response.getOutputStream();
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        return response.getWriter();
     }
 }

--- a/ozark/src/main/java/org/glassfish/ozark/jersey/OzarkFeature.java
+++ b/ozark/src/main/java/org/glassfish/ozark/jersey/OzarkFeature.java
@@ -41,10 +41,11 @@ package org.glassfish.ozark.jersey;
 
 import org.glassfish.jersey.internal.spi.AutoDiscoverable;
 import org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable;
-import org.glassfish.ozark.MvcContextImpl;
+import org.glassfish.ozark.MvcAppConfig;
 import org.glassfish.ozark.core.ViewRequestFilter;
 import org.glassfish.ozark.core.ViewResponseFilter;
 import org.glassfish.ozark.core.ViewableWriter;
+import org.glassfish.ozark.locale.LocaleRequestFilter;
 import org.glassfish.ozark.security.CsrfProtectFilter;
 import org.glassfish.ozark.security.CsrfValidateInterceptor;
 import org.glassfish.ozark.binding.BindingInterceptorImpl;
@@ -97,12 +98,13 @@ public class OzarkFeature implements ForcedAutoDiscoverable {
             context.register(OzarkModelProcessor.class);
             context.register(CsrfValidateInterceptor.class);
             context.register(CsrfProtectFilter.class);
+            context.register(LocaleRequestFilter.class);
 
             // Initialize application config object in Mvc class
             final BeanManager bm = CDI.current().getBeanManager();
-            final MvcContextImpl mvc = (MvcContextImpl) newBean(bm, MvcContextImpl.class);
-            mvc.setConfig(config);
-            mvc.setContextPath(servletContext.getContextPath());
+            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
+            appConfig.setConfig(config);
+            appConfig.setContextPath(servletContext.getContextPath());
         }
     }
 

--- a/ozark/src/main/java/org/glassfish/ozark/locale/LocaleResolverChain.java
+++ b/ozark/src/main/java/org/glassfish/ozark/locale/LocaleResolverChain.java
@@ -1,0 +1,126 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.locale;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.mvc.locale.LocaleResolver;
+import javax.mvc.locale.LocaleResolverContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Context;
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Implements the locale resolving algorithm described in {@link LocaleResolver}.
+ *
+ * @author Christian Kaltepoth
+ */
+@ApplicationScoped
+public class LocaleResolverChain {
+
+    @Inject
+    @Any
+    private Instance<LocaleResolver> resolvers;
+
+    @Inject
+    private HttpServletRequest request;
+
+    @Context
+    private Configuration configuration;
+
+    @PostConstruct
+    public void verify() {
+        Objects.requireNonNull(configuration, "The Configuration instance was not injected! " +
+                "Please make sure you are using a recent version of Jersey.");
+    }
+
+    public Locale resolve(ContainerRequestContext requestContext) {
+
+        // prepare context instance
+        LocaleResolverContext context = new LocaleResolverContextImpl(configuration, requestContext);
+
+        // candidates as sorted list
+        List<LocaleResolver> candidates = StreamSupport.stream(resolvers.spliterator(), false)
+                .sorted((resolver1, resolver2) -> {
+                    final Priority prio1 = getAnnotation(resolver1.getClass(), Priority.class);
+                    final Priority prio2 = getAnnotation(resolver2.getClass(), Priority.class);
+                    final int value1 = prio1 != null ? prio1.value() : 1000;
+                    final int value2 = prio2 != null ? prio2.value() : 1000;
+                    return value2 - value1;
+                })
+                .collect(Collectors.toList());
+
+        // do the resolving
+        for (LocaleResolver candidate : candidates) {
+            Locale locale = candidate.resolveLocale(context);
+            if (locale != null) {
+                return locale;
+            }
+        }
+
+        throw new IllegalStateException("Could not resolve locale with any of the " + candidates.size()
+                + " resolver implementations");
+
+    }
+
+    /**
+     * It looks like {@link org.glassfish.ozark.util.AnnotationUtils#getAnnotation(Class, Class)}
+     * still doesn't handle proxies correctly. This method handles proxies correctly
+     * but unfortunately only works with Weld.
+     */
+    private <T extends Annotation> T getAnnotation(Class<?> clazz, Class<T> annotationType) {
+        if (clazz.getName().endsWith("$$_WeldClientProxy")) {
+            return clazz.getSuperclass().getAnnotation(annotationType);
+        }
+        return clazz.getAnnotation(annotationType);
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/locale/LocaleResolverChain.java
+++ b/ozark/src/main/java/org/glassfish/ozark/locale/LocaleResolverChain.java
@@ -47,7 +47,6 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.mvc.locale.LocaleResolver;
 import javax.mvc.locale.LocaleResolverContext;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Context;
@@ -69,9 +68,6 @@ public class LocaleResolverChain {
     @Inject
     @Any
     private Instance<LocaleResolver> resolvers;
-
-    @Inject
-    private HttpServletRequest request;
 
     @Context
     private Configuration configuration;

--- a/ozark/src/main/java/org/glassfish/ozark/locale/LocaleResolverContextImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/locale/LocaleResolverContextImpl.java
@@ -37,42 +37,60 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.servlet;
+package org.glassfish.ozark.locale;
 
-import org.glassfish.ozark.MvcAppConfig;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HandlesTypes;
-import javax.ws.rs.ApplicationPath;
-import java.util.Set;
-
-import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.CdiUtils.newBean;
+import javax.mvc.locale.LocaleResolverContext;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.Locale;
 
 /**
- * Initializes the Mvc class with the application and context path. Note that the
- * application path is only initialized if there is an application sub-class that
- * is annotated by {@link javax.ws.rs.ApplicationPath}.
+ * Implementation of the {@link LocaleResolverContext} interface.
  *
- * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  */
-@HandlesTypes({ ApplicationPath.class })
-public class OzarkContainerInitializer implements ServletContainerInitializer {
+public class LocaleResolverContextImpl implements LocaleResolverContext {
+
+    private final Configuration config;
+    private final ContainerRequestContext context;
+
+    public LocaleResolverContextImpl(Configuration config, ContainerRequestContext context) {
+        this.config = config;
+        this.context = context;
+    }
 
     @Override
-    public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
-        if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final BeanManager bm = CDI.current().getBeanManager();
-            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                appConfig.setApplicationPath(ap.value());
-            }
-        }
+    public Configuration getConfiguration() {
+        return config;
     }
+
+    @Override
+    public List<Locale> getAcceptableLanguages() {
+        return context.getAcceptableLanguages();
+    }
+
+    @Override
+    public Request getRequest() {
+        return context.getRequest();
+    }
+
+    @Override
+    public UriInfo getUriInfo() {
+        return context.getUriInfo();
+    }
+
+    @Override
+    public Cookie getCookie(String name) {
+        return context.getCookies().get(name);
+    }
+
+    @Override
+    public String getHeaderString(String name) {
+        return context.getHeaderString(name);
+    }
+
 }

--- a/ozark/src/main/java/org/glassfish/ozark/security/CsrfValidateInterceptor.java
+++ b/ozark/src/main/java/org/glassfish/ozark/security/CsrfValidateInterceptor.java
@@ -179,7 +179,7 @@ public class CsrfValidateInterceptor implements ReaderInterceptor {
     private String toString(ByteArrayInputStream bais, String encoding) throws UnsupportedEncodingException {
         int n = 0;
         final byte[] bb = new byte[bais.available()];
-        while ((n = bais.read(bb, n, bb.length - n)) >= 0) ;
+        while ((n = bais.read(bb, n, bb.length - n)) >= 0); // NOPMD ignore empty while block
         bais.reset();
         return new String(bb, encoding);
     }

--- a/ozark/src/main/java/org/glassfish/ozark/servlet/OzarkContainerInitializer.java
+++ b/ozark/src/main/java/org/glassfish/ozark/servlet/OzarkContainerInitializer.java
@@ -39,10 +39,6 @@
  */
 package org.glassfish.ozark.servlet;
 
-import org.glassfish.ozark.MvcAppConfig;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -51,7 +47,6 @@ import javax.ws.rs.ApplicationPath;
 import java.util.Set;
 
 import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.CdiUtils.newBean;
 
 /**
  * Initializes the Mvc class with the application and context path. Note that the
@@ -63,15 +58,15 @@ import static org.glassfish.ozark.util.CdiUtils.newBean;
 @HandlesTypes({ ApplicationPath.class })
 public class OzarkContainerInitializer implements ServletContainerInitializer {
 
+    public static final String APP_PATH_CONTEXT_KEY = OzarkContainerInitializer.class.getName() + ".APP_PATH";
+
     @Override
     public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
         if (classes != null && !classes.isEmpty()) {
             final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final BeanManager bm = CDI.current().getBeanManager();
-            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
             final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
             if (ap != null) {
-                appConfig.setApplicationPath(ap.value());
+                servletContext.setAttribute(APP_PATH_CONTEXT_KEY, ap.value());
             }
         }
     }

--- a/ozark/src/main/java/org/glassfish/ozark/util/AnnotationUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/util/AnnotationUtils.java
@@ -139,7 +139,7 @@ public final class AnnotationUtils {
                 try {
                     final Method superMethod = superClass.getDeclaredMethod(method.getName(), method.getParameterTypes());
                     an = getAnnotation(superMethod, annotationType);
-                } catch (NoSuchMethodException e) {
+                } catch (NoSuchMethodException e) { // NOPMD ignore empty catch block
                     // falls through
                 }
                 if (an != null) {
@@ -153,7 +153,7 @@ public final class AnnotationUtils {
                 try {
                     final Method superMethod = in.getDeclaredMethod(method.getName(), method.getParameterTypes());
                     an = getAnnotation(superMethod, annotationType);
-                } catch (NoSuchMethodException e) {
+                } catch (NoSuchMethodException e) { // NOPMD ignore empty catch block
                     // falls through
                 }
                 if (an != null) {

--- a/ozark/src/main/java/org/glassfish/ozark/util/PathUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/util/PathUtils.java
@@ -132,7 +132,7 @@ public final class PathUtils {
      */
     public static String normalizePath(String path) {
         Objects.requireNonNull(path, "path must not be null");
-        return (path.isEmpty() || path.equals("/*")) ? "" : ensureNotEndingSlash(ensureStartingSlash(path));
+        return path.isEmpty() || path.equals("/*") ? "" : ensureNotEndingSlash(ensureStartingSlash(path));
     }
     
 }

--- a/ozark/src/test/java/org/glassfish/ozark/binding/ConstraintViolationUtilsTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/binding/ConstraintViolationUtilsTest.java
@@ -1,0 +1,194 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.binding;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.mvc.annotation.Controller;
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Min;
+import javax.validation.executable.ExecutableValidator;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ConstraintViolationUtilsTest {
+
+    private static final long VALID = 10;
+    private static final long INVALID = -10;
+
+    @Test
+    public void shouldSupportControllerFields() {
+
+        SomeController controller = new SomeController();
+        controller.setControllerField(INVALID);
+
+        long methodParameter = VALID;
+
+        BeanParamBean paramBean = new BeanParamBean();
+        paramBean.setBeanParamField(VALID);
+
+        List<ConstraintViolation<?>> violations = simulateValidation(
+                controller, "someControllerMethod", methodParameter, paramBean);
+
+        Assert.assertEquals(1, violations.size());
+        Assert.assertEquals("controller-field",
+                ConstraintViolationUtils.getParamName(violations.get(0)));
+
+    }
+
+    @Test
+    public void shouldSupportMethodParameters() {
+
+        SomeController controller = new SomeController();
+        controller.setControllerField(VALID);
+
+        long methodParameter = INVALID;
+
+        BeanParamBean paramBean = new BeanParamBean();
+        paramBean.setBeanParamField(VALID);
+
+        List<ConstraintViolation<?>> violations = simulateValidation(
+                controller, "someControllerMethod", methodParameter, paramBean);
+
+        Assert.assertEquals(1, violations.size());
+        Assert.assertEquals("method-parameter",
+                ConstraintViolationUtils.getParamName(violations.get(0)));
+
+    }
+
+
+    @Test
+    public void shouldSupportBeanParamBeans() {
+
+        SomeController controller = new SomeController();
+        controller.setControllerField(VALID);
+
+        long methodParameter = VALID;
+
+        BeanParamBean paramBean = new BeanParamBean();
+        paramBean.setBeanParamField(INVALID);
+
+        List<ConstraintViolation<?>> violations = simulateValidation(
+                controller, "someControllerMethod", methodParameter, paramBean);
+
+        Assert.assertEquals(1, violations.size());
+        Assert.assertEquals("bean-param-field",
+                ConstraintViolationUtils.getParamName(violations.get(0)));
+
+    }
+
+    private List<ConstraintViolation<?>> simulateValidation(Object controller, String methodName, Object... args) {
+
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+
+        Validator validator = validatorFactory.getValidator();
+        ExecutableValidator executableValidator = validator.forExecutables();
+
+        List<ConstraintViolation<?>> result = new ArrayList<>();
+
+        // validate controller fields
+        result.addAll(validator.validate(controller));
+
+        // controller method parameters
+        Method method = getFirstMethod(controller.getClass(), methodName);
+        result.addAll(executableValidator.validateParameters(controller, method, args));
+
+        return result;
+
+    }
+
+    private Method getFirstMethod(Class<?> clazz, String methodName) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                return method;
+            }
+        }
+        throw new IllegalStateException("Canot find method: " + methodName);
+    }
+
+    @Controller
+    @Path("something")
+    public static class SomeController {
+
+        @QueryParam("controller-field")
+        @Min(0)
+        private Long controllerField;
+
+        @POST
+        public String someControllerMethod(
+                @FormParam("method-parameter") @Min(0) Long methodParameter,
+                @BeanParam @Valid BeanParamBean beanParam) {
+            return "view.jsp";
+        }
+
+        public void setControllerField(Long controllerField) {
+            this.controllerField = controllerField;
+        }
+
+    }
+
+    public static class BeanParamBean {
+
+        @FormParam("bean-param-field")
+        @Min(0)
+        private long beanParamField;
+
+        public long getBeanParamField() {
+            return beanParamField;
+        }
+
+        public void setBeanParamField(long beanParamField) {
+            this.beanParamField = beanParamField;
+        }
+    }
+
+
+}

--- a/ozark/src/test/java/org/glassfish/ozark/core/ViewableWriterTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/core/ViewableWriterTest.java
@@ -43,6 +43,8 @@ import org.easymock.EasyMock;
 import org.glassfish.ozark.engine.ViewEngineFinder;
 import org.junit.Test;
 
+import javax.enterprise.event.Event;
+import javax.mvc.event.MvcEvent;
 import javax.ws.rs.core.Configuration;
 import javax.mvc.Viewable;
 import javax.mvc.engine.ViewEngine;
@@ -108,6 +110,11 @@ public class ViewableWriterTest {
         Field requestField = writer.getClass().getDeclaredField("request");
         requestField.setAccessible(true);
         requestField.set(writer, request);
+
+        Event<MvcEvent> dispatcher = EasyMock.createStrictMock(Event.class);
+        Field dispatcherField = writer.getClass().getDeclaredField("dispatcher");
+        dispatcherField.setAccessible(true);
+        dispatcherField.set(writer, dispatcher);
         
         ViewEngine viewEngine = EasyMock.createStrictMock(ViewEngine.class);
         
@@ -131,7 +138,7 @@ public class ViewableWriterTest {
 
         expect(finder.find(anyObject())).andReturn(viewEngine);
         viewEngine.processView((ViewEngineContext) anyObject());
-        
+
         replay(finder, request, viewEngine, response);
         writer.writeTo(viewable, null, null, new Annotation[] {}, MediaType.WILDCARD_TYPE, map, null);
         verify(finder, request, viewEngine, response);

--- a/ozark/src/test/java/org/glassfish/ozark/engine/OzarkViewEngineContextTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/engine/OzarkViewEngineContextTest.java
@@ -56,14 +56,14 @@ import static org.junit.Assert.*;
  * 
  * @author Manfred Riem (manfred.riem at oracle.com)
  */
-public class ViewEngineContextImplTest {
+public class OzarkViewEngineContextTest {
     
     /**
      * Test getView method.
      */
     @Test
     public void testGetView() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl("view", null, null, null, null, null, null);
+        OzarkViewEngineContext context = new OzarkViewEngineContext("view", null, null, null, null, null, null);
         assertEquals("view", context.getView());
     }
     
@@ -72,9 +72,9 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetModels() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        OzarkViewEngineContext context = new OzarkViewEngineContext(null, null, null, null, null, null, null);
         assertNull(context.getModels());
-        context = new ViewEngineContextImpl(null, new ModelsImpl(), null, null, null, null, null);
+        context = new OzarkViewEngineContext(null, new ModelsImpl(), null, null, null, null, null);
         assertNotNull(context.getModels());
     }
     
@@ -83,11 +83,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetRequest() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        OzarkViewEngineContext context = new OzarkViewEngineContext(null, null, null, null, null, null, null);
         assertNull(context.getRequest());
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         replay(request);
-        context = new ViewEngineContextImpl(null, null, request, null, null, null, null);
+        context = new OzarkViewEngineContext(null, null, request, null, null, null, null);
         assertNotNull(context.getRequest());
         verify(request);
     }
@@ -97,11 +97,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetResponse() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        OzarkViewEngineContext context = new OzarkViewEngineContext(null, null, null, null, null, null, null);
         assertNull(context.getResponse());
         HttpServletResponse response = EasyMock.createMock(HttpServletResponse.class);
         replay(response);
-        context = new ViewEngineContextImpl(null, null, null, response, null, null, null);
+        context = new OzarkViewEngineContext(null, null, null, response, null, null, null);
         assertNotNull(context.getResponse());
         verify(response);
     }
@@ -111,11 +111,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetUriInfo() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        OzarkViewEngineContext context = new OzarkViewEngineContext(null, null, null, null, null, null, null);
         assertNull(context.getUriInfo());
         UriInfo uriInfo = EasyMock.createMock(UriInfo.class);
         replay(uriInfo);
-        context = new ViewEngineContextImpl(null, null, null, null, uriInfo, null, null);
+        context = new OzarkViewEngineContext(null, null, null, null, uriInfo, null, null);
         assertNotNull(context.getUriInfo());
         verify(uriInfo);
     }
@@ -125,11 +125,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetResourceInfo() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        OzarkViewEngineContext context = new OzarkViewEngineContext(null, null, null, null, null, null, null);
         assertNull(context.getResourceInfo());
         ResourceInfo resourceInfo = EasyMock.createMock(ResourceInfo.class);
         replay(resourceInfo);
-        context = new ViewEngineContextImpl(null, null, null, null, null, resourceInfo, null);
+        context = new OzarkViewEngineContext(null, null, null, null, null, resourceInfo, null);
         assertNotNull(context.getResourceInfo());
         verify(resourceInfo);
     }
@@ -139,11 +139,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetConfiguration() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        OzarkViewEngineContext context = new OzarkViewEngineContext(null, null, null, null, null, null, null);
         assertNull(context.getConfiguration());
         Configuration config = EasyMock.createMock(Configuration.class);
         replay(config);
-        context = new ViewEngineContextImpl(null, null, null, null, null, null, config);
+        context = new OzarkViewEngineContext(null, null, null, null, null, null, config);
         assertNotNull(context.getConfiguration());
         verify(config);
     }

--- a/ozark/src/test/java/org/glassfish/ozark/util/AnnotationUtilsTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/util/AnnotationUtilsTest.java
@@ -39,14 +39,13 @@
  */
 package org.glassfish.ozark.util;
 
-import org.jglue.cdiunit.CdiRunner;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Provider;
 import javax.mvc.annotation.Controller;
 import javax.mvc.annotation.View;
 import javax.validation.constraints.NotNull;
@@ -62,7 +61,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Florian Hirsch
  */
-@RunWith(CdiRunner.class)
+@RunWith(CdiTestRunner.class)
 public class AnnotationUtilsTest {
 
 	@Inject

--- a/ozark/src/test/resources/META-INF/beans.xml
+++ b/ozark/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/ozark/src/test/resources/logging.properties
+++ b/ozark/src/test/resources/logging.properties
@@ -1,0 +1,11 @@
+.handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-6s %2$s %5$s%6$s%n
+
+.level=INFO
+# setting everything to WARNING as deltaspike test-control changes the log level...
+# see: https://issues.apache.org/jira/browse/DELTASPIKE-1133
+java.util.logging.ConsoleHandler.level=WARNING
+
+#org.apache.deltaspike.level=WARNING
+org.jboss.weld.level=SEVERE

--- a/test/locale/pom.xml
+++ b/test/locale/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.ozark.test</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-m03-SNAPSHOT</version>
+    </parent>
+    <artifactId>locale</artifactId>
+    <packaging>war</packaging>
+    <name>Ozark ${project.version} Locale Tests</name>
+    <build>
+        <finalName>test-locale</finalName>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>${jersey.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+</project>

--- a/test/locale/src/main/java/org/glassfish/ozark/test/locale/LocaleController.java
+++ b/test/locale/src/main/java/org/glassfish/ozark/test/locale/LocaleController.java
@@ -37,42 +37,24 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.servlet;
+package org.glassfish.ozark.test.locale;
 
-import org.glassfish.ozark.MvcAppConfig;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HandlesTypes;
-import javax.ws.rs.ApplicationPath;
-import java.util.Set;
-
-import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.CdiUtils.newBean;
+import javax.mvc.annotation.Controller;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
 
 /**
- * Initializes the Mvc class with the application and context path. Note that the
- * application path is only initialized if there is an application sub-class that
- * is annotated by {@link javax.ws.rs.ApplicationPath}.
+ * Class LocaleController.
  *
- * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  */
-@HandlesTypes({ ApplicationPath.class })
-public class OzarkContainerInitializer implements ServletContainerInitializer {
+@Controller
+@Path("/locale")
+public class LocaleController {
 
-    @Override
-    public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
-        if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final BeanManager bm = CDI.current().getBeanManager();
-            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                appConfig.setApplicationPath(ap.value());
-            }
-        }
+    @GET
+    public String get() {
+        return "locale.jsp";
     }
+
 }

--- a/test/locale/src/main/java/org/glassfish/ozark/test/locale/MyApplication.java
+++ b/test/locale/src/main/java/org/glassfish/ozark/test/locale/MyApplication.java
@@ -37,42 +37,37 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.servlet;
+package org.glassfish.ozark.test.locale;
 
-import org.glassfish.ozark.MvcAppConfig;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HandlesTypes;
+import javax.mvc.locale.LocaleResolver;
 import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
-import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.CdiUtils.newBean;
-
 /**
- * Initializes the Mvc class with the application and context path. Note that the
- * application path is only initialized if there is an application sub-class that
- * is annotated by {@link javax.ws.rs.ApplicationPath}.
+ * Class MyApplication.
  *
- * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  */
-@HandlesTypes({ ApplicationPath.class })
-public class OzarkContainerInitializer implements ServletContainerInitializer {
+@ApplicationPath("resources")
+public class MyApplication extends Application {
 
     @Override
-    public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
-        if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final BeanManager bm = CDI.current().getBeanManager();
-            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                appConfig.setApplicationPath(ap.value());
-            }
-        }
+    public Set<Class<?>> getClasses() {
+        final Set<Class<?>> set = new HashSet<>();
+        set.add(LocaleController.class);
+        return set;
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        // Application default locale: fr
+        properties.put(LocaleResolver.DEFAULT_LOCALE, Locale.FRENCH);
+        return properties;
     }
 }

--- a/test/locale/src/main/java/org/glassfish/ozark/test/locale/QueryLocaleResolver.java
+++ b/test/locale/src/main/java/org/glassfish/ozark/test/locale/QueryLocaleResolver.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,42 +37,34 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.servlet;
+package org.glassfish.ozark.test.locale;
 
-import org.glassfish.ozark.MvcAppConfig;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HandlesTypes;
-import javax.ws.rs.ApplicationPath;
-import java.util.Set;
-
-import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.CdiUtils.newBean;
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.mvc.locale.LocaleResolver;
+import javax.mvc.locale.LocaleResolverContext;
+import java.util.List;
+import java.util.Locale;
 
 /**
- * Initializes the Mvc class with the application and context path. Note that the
- * application path is only initialized if there is an application sub-class that
- * is annotated by {@link javax.ws.rs.ApplicationPath}.
+ * Custom locale resolver
  *
- * @author Santiago Pericas-Geertsen
+ * @author Christian Kaltepoth
  */
-@HandlesTypes({ ApplicationPath.class })
-public class OzarkContainerInitializer implements ServletContainerInitializer {
+@ApplicationScoped
+@Priority(1000)  // = default priority for user provided resolvers
+public class QueryLocaleResolver implements LocaleResolver {
 
     @Override
-    public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
-        if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final BeanManager bm = CDI.current().getBeanManager();
-            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                appConfig.setApplicationPath(ap.value());
-            }
+    public Locale resolveLocale(LocaleResolverContext context) {
+
+        List<String> lang = context.getUriInfo().getQueryParameters().get("lang");
+        if (lang != null && !lang.isEmpty()) {
+            return new Locale(lang.get(0));
         }
+
+        return null;
+
     }
+
 }

--- a/test/locale/src/main/resources/LICENSE.txt
+++ b/test/locale/src/main/resources/LICENSE.txt
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -37,42 +37,4 @@
  * only if the new code is made subject to such option by the copyright
  * holder.
  */
-package org.glassfish.ozark.servlet;
 
-import org.glassfish.ozark.MvcAppConfig;
-
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.HandlesTypes;
-import javax.ws.rs.ApplicationPath;
-import java.util.Set;
-
-import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
-import static org.glassfish.ozark.util.CdiUtils.newBean;
-
-/**
- * Initializes the Mvc class with the application and context path. Note that the
- * application path is only initialized if there is an application sub-class that
- * is annotated by {@link javax.ws.rs.ApplicationPath}.
- *
- * @author Santiago Pericas-Geertsen
- */
-@HandlesTypes({ ApplicationPath.class })
-public class OzarkContainerInitializer implements ServletContainerInitializer {
-
-    @Override
-    public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
-        if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final BeanManager bm = CDI.current().getBeanManager();
-            final MvcAppConfig appConfig = newBean(bm, MvcAppConfig.class);
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                appConfig.setApplicationPath(ap.value());
-            }
-        }
-    }
-}

--- a/test/locale/src/main/webapp/WEB-INF/beans.xml
+++ b/test/locale/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/test/locale/src/main/webapp/WEB-INF/views/locale.jsp
+++ b/test/locale/src/main/webapp/WEB-INF/views/locale.jsp
@@ -1,0 +1,11 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<html>
+<head>
+    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <title>Request Locale</title>
+</head>
+<body>
+    <h1>Request Locale</h1>
+    <p>Locale: ${mvc.locale}</p>
+</body>
+</html>

--- a/test/locale/src/main/webapp/index.html
+++ b/test/locale/src/main/webapp/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <link rel="stylesheet" type="text/css" href="ozark.css">
+    <head>
+        <title>Request Locale</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    </head>
+    <body>
+        <h1>Request Locale</h1>
+        <ul>
+            <li>
+                <a href="resources/locale">Default locale</a>
+            </li>
+            <li>
+                <a href="resources/locale?lang=fr">Custom resolver</a>
+            </li>
+        </ul>
+    </body>
+</html>

--- a/test/locale/src/main/webapp/ozark.css
+++ b/test/locale/src/main/webapp/ozark.css
@@ -1,0 +1,31 @@
+h1 {
+    color: steelblue;
+    font-size: 30px;
+}
+
+h2 {
+    color: steelblue;
+    font-size: 24px;
+    margin-top: 20px;
+}
+
+input {
+    width: 200px;
+    display: block;
+    border: 1px solid #999;
+    height: 25px;
+    margin-bottom: 5px;
+}
+
+input[type=submit] {
+    width: 150px;
+    padding: 5px 5px;
+    background: steelblue;
+    color: white;
+    border: 0 none;
+    cursor: pointer;
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    margin-top: 15px;
+}

--- a/test/locale/src/test/java/org/glassfish/ozark/test/locale/LocaleIT.java
+++ b/test/locale/src/test/java/org/glassfish/ozark/test/locale/LocaleIT.java
@@ -1,0 +1,112 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.test.locale;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Kaltepoth
+ */
+public class LocaleIT {
+
+    public static final String ACCEPT_LANGUAGE = "Accept-Language";
+
+    private String webUrl;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.closeAllWindows();
+    }
+
+    @Test
+    public void testApplicationDefaultLocale() throws Exception {
+
+        // Send request with an invalid/missing "Accept-Language" header
+        webClient.addRequestHeader(ACCEPT_LANGUAGE, "");
+
+        // The default resolver returns the application default locale -> fr
+        HtmlPage page = webClient.getPage(webUrl + "resources/locale");
+        assertThat(page.getWebResponse().getContentAsString(),
+                CoreMatchers.containsString("<p>Locale: fr</p>"));
+
+    }
+
+    @Test
+    public void testLocaleFromAcceptLanguageHeader() throws Exception {
+
+        // Accept-Language header for "it"
+        webClient.addRequestHeader("Accept-Language", "it");
+
+        // The default resolver prefers the locale from the header
+        HtmlPage page = webClient.getPage(webUrl + "resources/locale");
+        assertThat(page.getWebResponse().getContentAsString(),
+                CoreMatchers.containsString("<p>Locale: it</p>"));
+    }
+
+    @Test
+    public void testCustomLocaleResolverWins() throws Exception {
+
+        // the default resolver would resolve "it"
+        webClient.addRequestHeader("Accept-Language", "it");
+
+        // custom resolver uses "lang" query parameter
+        HtmlPage page = webClient.getPage(webUrl + "resources/locale?lang=pl");
+
+        // the customer resolver wins
+        assertThat(page.getWebResponse().getContentAsString(),
+                CoreMatchers.containsString("<p>Locale: pl</p>"));
+
+    }
+
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -86,7 +86,7 @@
                 <dependency>
                     <groupId>javax.mvc</groupId>
                     <artifactId>javax.mvc-api</artifactId>
-                    <version>1.0-edr2</version>
+                    <version>1.0-SNAPSHOT</version>
                     <scope>compile</scope>
                 </dependency>
                 <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -60,6 +60,7 @@
         <module>handlebars</module>
         <module>jade</module>
         <module>jsr223</module>
+        <module>locale</module>
         <module>mustache</module>
         <module>mvc</module>
         <module>produces</module>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -363,5 +363,6 @@
     </profiles>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -72,6 +72,7 @@
         <module>stringtemplate</module>
         <module>thymeleaf</module>
         <module>validation</module>
+        <module>validation-i18n</module>
         <module>velocity</module>
         <module>view-annotation</module>
     </modules>

--- a/test/validation-i18n/pom.xml
+++ b/test/validation-i18n/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.glassfish.ozark.test</groupId>
+        <artifactId>parent</artifactId>
+        <version>1.0.0-m03-SNAPSHOT</version>
+    </parent>
+    <artifactId>validation-i18n</artifactId>
+    <packaging>war</packaging>
+    <name>Ozark ${project.version} Validation I18N Tests</name>
+    <build>
+        <finalName>test-validation-i18n</finalName>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>${jersey.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+            <version>1.2</version>
+        </dependency>
+    </dependencies>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+</project>

--- a/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/FormBean.java
+++ b/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/FormBean.java
@@ -1,0 +1,62 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.test.validation;
+
+import javax.validation.constraints.Size;
+import javax.ws.rs.FormParam;
+
+/**
+ * @author Christian Kaltepoth
+ */
+public class FormBean {
+
+    @FormParam("name")
+    @Size(min = 5, max = 10)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/MyApplication.java
+++ b/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/MyApplication.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.test.validation;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Christian Kaltepoth
+ */
+@ApplicationPath("resources")
+public class MyApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> set = new HashSet<>();
+        set.add(ValidationController.class);
+        return set;
+    }
+
+}

--- a/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/QueryLocaleResolver.java
+++ b/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/QueryLocaleResolver.java
@@ -1,0 +1,68 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.test.validation;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.mvc.locale.LocaleResolver;
+import javax.mvc.locale.LocaleResolverContext;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * @author Christian Kaltepoth
+ */
+@ApplicationScoped
+@Priority(1000)
+public class QueryLocaleResolver implements LocaleResolver {
+
+    @Override
+    public Locale resolveLocale(LocaleResolverContext context) {
+
+        List<String> lang = context.getUriInfo().getQueryParameters().get("lang");
+        if (lang != null && !lang.isEmpty()) {
+            return new Locale(lang.get(0));
+        }
+
+        return null;
+
+    }
+
+}

--- a/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/ValidationController.java
+++ b/test/validation-i18n/src/main/java/org/glassfish/ozark/test/validation/ValidationController.java
@@ -1,0 +1,93 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.test.validation;
+
+import javax.inject.Inject;
+import javax.mvc.Models;
+import javax.mvc.annotation.Controller;
+import javax.mvc.binding.BindingResult;
+import javax.mvc.binding.ValidationError;
+import javax.validation.Valid;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Christian Kaltepoth
+ */
+@Controller
+@Path("validation")
+public class ValidationController {
+
+    @Inject
+    private Models models;
+
+    @Inject
+    private BindingResult bindingResult;
+
+    @GET
+    public String get() {
+        return "form.jsp";
+    }
+
+    @POST
+    @ValidateOnExecution(type = ExecutableType.NONE)
+    public String post(@Valid @BeanParam FormBean form) {
+
+        if (bindingResult.isFailed()) {
+
+            List<String> errors = bindingResult.getAllValidationErrors().stream()
+                    .map(ValidationError::getMessage)
+                    .collect(Collectors.toList());
+
+            models.put("errors", errors);
+
+        }
+
+        return "form.jsp";
+
+    }
+
+}

--- a/test/validation-i18n/src/main/resources/LICENSE.txt
+++ b/test/validation-i18n/src/main/resources/LICENSE.txt
@@ -1,0 +1,40 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+

--- a/test/validation-i18n/src/main/webapp/WEB-INF/beans.xml
+++ b/test/validation-i18n/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/test/validation-i18n/src/main/webapp/WEB-INF/views/form.jsp
+++ b/test/validation-i18n/src/main/webapp/WEB-INF/views/form.jsp
@@ -1,0 +1,28 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+        <title>Validation</title>
+    </head>
+    <body>
+        <h1>Validation</h1>
+        <c:if test="${not empty errors}">
+            <ul>
+                <c:forEach var="error" items="${errors}">
+                    <li>${error}</li>
+                </c:forEach>
+            </ul>
+        </c:if>
+        <form name="form" method="POST"
+              action="./validation?lang=${pageContext.request.parameterMap['lang'][0]}">
+            <p>
+                <label for="name">Name:</label>
+                <input id="name" type="text" name="name"/>
+            </p>
+            <p>
+                <input name="button" type="submit" value="Submit"/>
+            </p>
+        </form>
+    </body>
+</html>

--- a/test/validation-i18n/src/main/webapp/index.html
+++ b/test/validation-i18n/src/main/webapp/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <link rel="stylesheet" type="text/css" href="ozark.css">
+    <head>
+        <title>Validation</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    </head>
+    <body>
+        <h1>Request Locale</h1>
+        <ul>
+            <li>
+                <a href="resources/validation?lang=en">Validation in English</a>
+            </li>
+            <li>
+                <a href="resources/validation?lang=de">Validation in German</a>
+            </li>
+            <li>
+                <a href="resources/validation?lang=fr">Validation in French</a>
+            </li>
+        </ul>
+    </body>
+</html>

--- a/test/validation-i18n/src/main/webapp/ozark.css
+++ b/test/validation-i18n/src/main/webapp/ozark.css
@@ -1,0 +1,31 @@
+h1 {
+    color: steelblue;
+    font-size: 30px;
+}
+
+h2 {
+    color: steelblue;
+    font-size: 24px;
+    margin-top: 20px;
+}
+
+input {
+    width: 200px;
+    display: block;
+    border: 1px solid #999;
+    height: 25px;
+    margin-bottom: 5px;
+}
+
+input[type=submit] {
+    width: 150px;
+    padding: 5px 5px;
+    background: steelblue;
+    color: white;
+    border: 0 none;
+    cursor: pointer;
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    margin-top: 15px;
+}

--- a/test/validation-i18n/src/test/java/org/glassfish/ozark/test/validation/I18NValidationIT.java
+++ b/test/validation-i18n/src/test/java/org/glassfish/ozark/test/validation/I18NValidationIT.java
@@ -1,0 +1,110 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014-2015 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * http://glassfish.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.ozark.test.validation;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Kaltepoth
+ */
+public class I18NValidationIT {
+
+    private String webUrl;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.closeAllWindows();
+    }
+
+    @Test
+    public void testEnglishValidationMessage() throws Exception {
+
+        HtmlPage page1 = webClient.getPage(webUrl + "resources/validation?lang=en");
+        HtmlForm form1 = page1.getFormByName("form");
+        form1.getInputByName("name").setValueAttribute("foo");
+
+        HtmlPage page2 = form1.getInputByName("button").click();
+        assertThat(page2.getWebResponse().getContentAsString(),
+                CoreMatchers.containsString("size must be between 5 and 10"));
+
+    }
+
+    @Test
+    public void testGermanValidationMessage() throws Exception {
+
+        HtmlPage page1 = webClient.getPage(webUrl + "resources/validation?lang=de");
+        HtmlForm form1 = page1.getFormByName("form");
+        form1.getInputByName("name").setValueAttribute("foo");
+
+        HtmlPage page2 = form1.getInputByName("button").click();
+        assertThat(page2.getWebResponse().getContentAsString(),
+                CoreMatchers.containsString("muss zwischen 5 und 10 liegen"));
+
+    }
+
+    @Test
+    public void testFrenchValidationMessage() throws Exception {
+
+        HtmlPage page1 = webClient.getPage(webUrl + "resources/validation?lang=fr");
+        HtmlForm form1 = page1.getFormByName("form");
+        form1.getInputByName("name").setValueAttribute("foo");
+
+        HtmlPage page2 = form1.getInputByName("button").click();
+        assertThat(page2.getWebResponse().getContentAsString(),
+                CoreMatchers.containsString("la taille doit \u00eatre entre 5 et 10"));
+
+    }
+
+}

--- a/test/validation/src/main/java/org/glassfish/ozark/test/validation/ErrorDataBean.java
+++ b/test/validation/src/main/java/org/glassfish/ozark/test/validation/ErrorDataBean.java
@@ -57,6 +57,8 @@ public class ErrorDataBean {
 
     private String message;
 
+    private String param;
+
     public String getProperty() {
         return property;
     }
@@ -79,5 +81,13 @@ public class ErrorDataBean {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getParam() {
+        return param;
+    }
+
+    public void setParam(String param) {
+        this.param = param;
     }
 }

--- a/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormController.java
+++ b/test/validation/src/main/java/org/glassfish/ozark/test/validation/FormController.java
@@ -44,6 +44,7 @@ import javax.inject.Inject;
 import javax.mvc.annotation.Controller;
 import javax.mvc.binding.BindingError;
 import javax.mvc.binding.BindingResult;
+import javax.mvc.binding.ValidationError;
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.executable.ExecutableType;
@@ -56,7 +57,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import java.util.Set;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -82,12 +82,13 @@ public class FormController {
     @ValidateOnExecution(type = ExecutableType.NONE)
     public Response formPost(@Valid @BeanParam FormDataBean form) {
         if (br.isFailed()) {
-            final Set<ConstraintViolation<?>> set = br.getAllViolations();
-            final ConstraintViolation<?> cv = set.iterator().next();
+            ValidationError validationError = br.getAllValidationErrors().iterator().next();
+            final ConstraintViolation<?> cv = validationError.getViolation();
             final String property = cv.getPropertyPath().toString();
             error.setProperty(property.substring(property.lastIndexOf('.') + 1));
             error.setValue(cv.getInvalidValue());
             error.setMessage(cv.getMessage());
+            error.setParam(validationError.getParamName());
             return Response.status(BAD_REQUEST).entity("error.jsp").build();
         }
         return Response.status(OK).entity("data.jsp").build();

--- a/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
@@ -6,6 +6,7 @@
 </head>
 <body>
     <h1>Binding Error</h1>
-    <p>Param: ${error.property}</p>
+    <p>Property: ${error.property}</p>
+    <p>Param: ${error.param}</p>
     <p>Message: ${error.message}</p>
 </html>

--- a/test/validation/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/error.jsp
@@ -7,6 +7,7 @@
 <body>
     <h1>Form Error</h1>
     <p>Property: ${error.property}</p>
+    <p>Param: ${error.param}</p>
     <p>Value: ${error.value}</p>
     <p>Message: ${error.message}</p>
 </html>

--- a/test/validation/src/test/java/org/glassfish/ozark/test/validation/ValidationIT.java
+++ b/test/validation/src/test/java/org/glassfish/ozark/test/validation/ValidationIT.java
@@ -98,6 +98,7 @@ public class ValidationIT {
         } catch (FailingHttpStatusCodeException e) {
             assertTrue(e.getStatusCode() == 400);
             assertTrue(e.getResponse().getContentAsString().contains("<h1>Form Error</h1>"));
+            assertTrue(e.getResponse().getContentAsString().contains("<p>Param: age</p>"));
         }
     }
 
@@ -131,6 +132,7 @@ public class ValidationIT {
         } catch (FailingHttpStatusCodeException e) {
             assertTrue(e.getStatusCode() == 400);
             assertTrue(e.getResponse().getContentAsString().contains("<h1>Form Error</h1>"));
+            assertTrue(e.getResponse().getContentAsString().contains("<p>Param: age</p>"));
         }
     }
 

--- a/test/view-annotation/src/main/java/org/glassfish/ozark/test/view/HelloController.java
+++ b/test/view-annotation/src/main/java/org/glassfish/ozark/test/view/HelloController.java
@@ -41,13 +41,9 @@ package org.glassfish.ozark.test.view;
 
 import javax.mvc.annotation.Controller;
 import javax.mvc.annotation.View;
-import javax.mvc.Viewable;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.Response;
-import java.util.Locale;
 
 /**
  * Tests uses of {@code View} annotation with void and non-void methods. If a method
@@ -126,4 +122,45 @@ public class HelloController {
     public String nullControllerClass() {
         return null;
     }
+
+    /**
+     * Void method that throws a ForbiddenException. View 'hello.jsp' should be rendered.
+     */
+    @GET
+    @Path("void/forbidden")
+    @View("hello.jsp")
+    public void voidForbiddenException() {
+        throw new ForbiddenException();
+    }
+
+    /**
+     * Void method that throws a IllegalArgumentException. Error page defined in web.xml should be rendered.
+     */
+    @GET
+    @Path("void/illegal-argument")
+    @View("hello.jsp")
+    public void voidIllegalArgumentException() {
+        throw new IllegalArgumentException("the general error page should be displayed");
+    }
+
+    /**
+     * Method that throws a ForbiddenException. View 'hello.jsp' should be rendered.
+     */
+    @GET
+    @Path("string/forbidden")
+    @View("hello.jsp")
+    public String stringForbiddenException() {
+        throw new ForbiddenException();
+    }
+
+    /**
+     * Method that throws a IllegalArgumentException. Error page defined in web.xml should be rendered.
+     */
+    @GET
+    @Path("string/illegal-argument")
+    @View("hello.jsp")
+    public String stringIllegalArgumentException() {
+        throw new IllegalArgumentException("the general error page should be displayed");
+    }
+
 }

--- a/test/view-annotation/src/main/java/org/glassfish/ozark/test/view/MyApplication.java
+++ b/test/view-annotation/src/main/java/org/glassfish/ozark/test/view/MyApplication.java
@@ -39,8 +39,6 @@
  */
 package org.glassfish.ozark.test.view;
 
-import org.glassfish.ozark.test.view.HelloController;
-
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 import java.util.Collections;

--- a/test/view-annotation/src/main/webapp/WEB-INF/web.xml
+++ b/test/view-annotation/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+    version="3.1" 
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+    <error-page>
+        <location>/error.html</location>
+    </error-page>
+</web-app>

--- a/test/view-annotation/src/main/webapp/error.html
+++ b/test/view-annotation/src/main/webapp/error.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>General Error Page</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" type="text/css" href="/test-view-annotation/ozark.css">
+</head>
+<body>
+<h1>Hello Error</h1>
+</body>
+</html>

--- a/test/view-annotation/src/main/webapp/index.html
+++ b/test/view-annotation/src/main/webapp/index.html
@@ -1,16 +1,25 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Hello Controller with @Produces</title>
+    <title>Hello Controller with @View</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <link rel="stylesheet" type="text/css" href="ozark.css">
 </head>
 <body>
-<h1>Hello Controller with @Produces</h1>
+<h1>Hello Controller with @View</h1>
 <ul>
-    <li><a href="resources/multiple_produces1">resources/multiple_produces1</a>
+    <li><a href="resources/void">Void method with @View annotation. View 'hello.jsp' should be rendered.</a>
+    <li><a href="resources/string">Method that overrides the @View annotation. View 'bye.jsp' should be rendered.</a>
+    <li><a href="resources/null">Method that returns a null value. View 'hello.jsp' should be rendered.</a>
+    <li><a href="resources/class/void">Void method with @View annotation from class. View 'hello.jsp' should be rendered.</a>
+    <li><a href="resources/class/string">Method that overrides the @View annotation from class. View 'bye.jsp' should be rendered.</a>
+    <li><a href="resources/class/null">Method that returns a null value. View 'hello.jsp' from class should be rendered.</a>
+    <li><a href="resources/void/forbidden">Void method that throws a ForbiddenException. View 'hello.jsp' should be rendered.</a>
+    <li><a href="resources/void/illegal-argument">Void method that throws a IllegalArgumentException. Error page defined in web.xml should be rendered.</a>
+    <li><a href="resources/string/forbidden">Method that throws a ForbiddenException. View 'hello.jsp' should be rendered.</a>
+    <li><a href="resources/string/illegal-argument">Method that throws a IllegalArgumentException. Error page defined in web.xml should be rendered.</a>
 </ul>
 <br/>
-<a class="source" href="https://java.net/projects/ozark/sources/sources/content/test/produces/src/main/java/com/oracle/ozark/test/produces/HelloController.java">Source Code</a>
+<a class="source" href="https://java.net/projects/ozark/sources/sources/content/test/view-annotation/src/main/java/com/oracle/ozark/test/view-annotation/HelloController.java">Source Code</a>
 </body>
 </html>

--- a/test/view-annotation/src/test/java/org/glassfish/ozark/test/view/ViewAnnotationIT.java
+++ b/test/view-annotation/src/test/java/org/glassfish/ozark/test/view/ViewAnnotationIT.java
@@ -48,6 +48,8 @@ import org.junit.Test;
 
 import java.util.Iterator;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ViewAnnotationIT {
@@ -59,6 +61,9 @@ public class ViewAnnotationIT {
     public void setUp() {
         webUrl = System.getProperty("integration.url");
         webClient = new WebClient();
+        // we explicitly want to test some status codes
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        webClient.getOptions().setPrintContentOnFailingStatusCode(false);
     }
 
     @After
@@ -69,6 +74,7 @@ public class ViewAnnotationIT {
     @Test
     public void testVoid() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/void");
+        assertThat(page.getWebResponse().getStatusCode(), is(200));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
         assertTrue(it.next().asText().contains("Hello World"));
     }
@@ -76,6 +82,7 @@ public class ViewAnnotationIT {
     @Test
     public void testString() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/string");
+        assertThat(page.getWebResponse().getStatusCode(), is(200));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
         assertTrue(it.next().asText().contains("Bye World"));
     }
@@ -83,6 +90,7 @@ public class ViewAnnotationIT {
     @Test
     public void testNull() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/null");
+        assertThat(page.getWebResponse().getStatusCode(), is(200));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
         assertTrue(it.next().asText().contains("Hello World"));
     }
@@ -90,6 +98,7 @@ public class ViewAnnotationIT {
     @Test
     public void testVoidClass() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/class/void");
+        assertThat(page.getWebResponse().getStatusCode(), is(200));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
         assertTrue(it.next().asText().contains("Hello World"));
     }
@@ -97,6 +106,7 @@ public class ViewAnnotationIT {
     @Test
     public void testStringClass() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/class/string");
+        assertThat(page.getWebResponse().getStatusCode(), is(200));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
         assertTrue(it.next().asText().contains("Bye World"));
     }
@@ -104,7 +114,41 @@ public class ViewAnnotationIT {
     @Test
     public void testNullClass() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/class/null");
+        assertThat(page.getWebResponse().getStatusCode(), is(200));
         final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
         assertTrue(it.next().asText().contains("Hello World"));
     }
+
+    @Test
+    public void testVoidForbiddenException() throws Exception {
+        final HtmlPage page = webClient.getPage(webUrl + "resources/void/forbidden");
+        assertThat(page.getWebResponse().getStatusCode(), is(403));
+        final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
+        assertTrue(it.next().asText().contains("Hello World"));
+    }
+
+    @Test
+    public void testVoidIllegalArgumentException() throws Exception {
+        final HtmlPage page = webClient.getPage(webUrl + "resources/void/illegal-argument");
+        assertThat(page.getWebResponse().getStatusCode(), is(500));
+        final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
+        assertTrue(it.next().asText().contains("Hello Error"));
+    }
+
+    @Test
+    public void testStringForbiddenException() throws Exception {
+        final HtmlPage page = webClient.getPage(webUrl + "resources/string/forbidden");
+        assertThat(page.getWebResponse().getStatusCode(), is(403));
+        final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
+        assertTrue(it.next().asText().contains("Hello World"));
+    }
+
+    @Test
+    public void testStringIllegalArgumentException() throws Exception {
+        final HtmlPage page = webClient.getPage(webUrl + "resources/string/illegal-argument");
+        assertThat(page.getWebResponse().getStatusCode(), is(500));
+        final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
+        assertTrue(it.next().asText().contains("Hello Error"));
+    }
+
 }


### PR DESCRIPTION
HttpServletRequest and HttpServletResponse removed from ViewEngineContext.
Implementation refactored according to https://github.com/mvc-spec/mvc-spec/pull/3

This fix will #close [OZARK-76](https://java.net/jira/browse/OZARK-76) 
