### PR TITLE
OZARK-81: Replacing CDI-Unit with Deltaspike Test-Control

### DIFF
--- a/ozark/pom.xml
+++ b/ozark/pom.xml
@@ -58,6 +58,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.config.file>src/test/resources/logging.properties</java.util.logging.config.file>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -137,9 +142,39 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jglue.cdi-unit</groupId>
-            <artifactId>cdi-unit</artifactId>
-            <version>3.1.3</version>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-api</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.core</groupId>
+            <artifactId>deltaspike-core-impl</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.modules</groupId>
+            <artifactId>deltaspike-test-control-module-api</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.modules</groupId>
+            <artifactId>deltaspike-test-control-module-impl</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.deltaspike.cdictrl</groupId>
+            <artifactId>deltaspike-cdictrl-weld</artifactId>
+            <version>1.6.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>2.2.13.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ozark/src/test/java/org/glassfish/ozark/core/ViewableWriterTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/core/ViewableWriterTest.java
@@ -43,6 +43,8 @@ import org.easymock.EasyMock;
 import org.glassfish.ozark.engine.ViewEngineFinder;
 import org.junit.Test;
 
+import javax.enterprise.event.Event;
+import javax.mvc.event.MvcEvent;
 import javax.ws.rs.core.Configuration;
 import javax.mvc.Viewable;
 import javax.mvc.engine.ViewEngine;
@@ -108,6 +110,11 @@ public class ViewableWriterTest {
         Field requestField = writer.getClass().getDeclaredField("request");
         requestField.setAccessible(true);
         requestField.set(writer, request);
+
+        Event<MvcEvent> dispatcher = EasyMock.createStrictMock(Event.class);
+        Field dispatcherField = writer.getClass().getDeclaredField("dispatcher");
+        dispatcherField.setAccessible(true);
+        dispatcherField.set(writer, dispatcher);
         
         ViewEngine viewEngine = EasyMock.createStrictMock(ViewEngine.class);
         
@@ -131,7 +138,7 @@ public class ViewableWriterTest {
 
         expect(finder.find(anyObject())).andReturn(viewEngine);
         viewEngine.processView((ViewEngineContext) anyObject());
-        
+
         replay(finder, request, viewEngine, response);
         writer.writeTo(viewable, null, null, new Annotation[] {}, MediaType.WILDCARD_TYPE, map, null);
         verify(finder, request, viewEngine, response);

--- a/ozark/src/test/java/org/glassfish/ozark/util/AnnotationUtilsTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/util/AnnotationUtilsTest.java
@@ -39,14 +39,13 @@
  */
 package org.glassfish.ozark.util;
 
-import org.jglue.cdiunit.CdiRunner;
+import org.apache.deltaspike.testcontrol.api.junit.CdiTestRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Provider;
 import javax.mvc.annotation.Controller;
 import javax.mvc.annotation.View;
 import javax.validation.constraints.NotNull;
@@ -62,7 +61,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Florian Hirsch
  */
-@RunWith(CdiRunner.class)
+@RunWith(CdiTestRunner.class)
 public class AnnotationUtilsTest {
 
 	@Inject

--- a/ozark/src/test/resources/META-INF/beans.xml
+++ b/ozark/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/ozark/src/test/resources/logging.properties
+++ b/ozark/src/test/resources/logging.properties
@@ -1,0 +1,11 @@
+.handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-6s %2$s %5$s%6$s%n
+
+.level=INFO
+# setting everything to WARNING as deltaspike test-control changes the log level...
+# see: https://issues.apache.org/jira/browse/DELTASPIKE-1133
+java.util.logging.ConsoleHandler.level=WARNING
+
+#org.apache.deltaspike.level=WARNING
+org.jboss.weld.level=SEVERE


### PR DESCRIPTION
Resolves [OZARK-81](https://java.net/jira/browse/OZARK-81).