### PR TITLE
Use latest promoted Glassfish 5 build for integration tests

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -5,22 +5,22 @@ set -e
 if [ "$1" == "glassfish-bundled" ]; then
 
   mvn -Pbundled clean install -B -V
-  find ./test/ -name \*.war -exec cp {} ./glassfish4/glassfish/domains/domain1/autodeploy/ \;
-  glassfish4/bin/asadmin start-domain
+  find ./test/ -name \*.war -exec cp {} ./glassfish5/glassfish/domains/domain1/autodeploy/ \;
+  glassfish5/bin/asadmin start-domain
   sleep 120
   mvn -Pintegration -Dintegration.serverPort=8080 verify
-  glassfish4/bin/asadmin stop-domain
+  glassfish5/bin/asadmin stop-domain
 
 elif [ "$1" == "glassfish-module" ]; then
 
   mvn -P\!bundled,module clean install -B -V
-  cp ozark/target/ozark-*.jar ./glassfish4/glassfish/modules/
-  cp ~/.m2/repository/javax/mvc/javax.mvc-api/1.0-SNAPSHOT/*.jar ./glassfish4/glassfish/modules/
-  find ./test/ -name \*.war -exec cp {} ./glassfish4/glassfish/domains/domain1/autodeploy/ \;
-  glassfish4/bin/asadmin start-domain
+  cp ozark/target/ozark-*.jar ./glassfish5/glassfish/modules/
+  cp ~/.m2/repository/javax/mvc/javax.mvc-api/1.0-SNAPSHOT/*.jar ./glassfish5/glassfish/modules/
+  find ./test/ -name \*.war -exec cp {} ./glassfish5/glassfish/domains/domain1/autodeploy/ \;
+  glassfish5/bin/asadmin start-domain
   sleep 120
   mvn -Pintegration -Dintegration.serverPort=8080 verify
-  glassfish4/bin/asadmin stop-domain
+  glassfish5/bin/asadmin stop-domain
 
 else
   echo "Unknown test type: $1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
   - TYPE=glassfish-bundled
 install:
   - mvn dependency:get -Dartifact=javax.mvc:javax.mvc-api:1.0-SNAPSHOT -DremoteRepositories=central::default::https://repo1.maven.org/maven2,javanet::default::https://maven.java.net/content/repositories/snapshots
-  - curl -s -o glassfish41.zip http://download.oracle.com/glassfish/4.1/nightly/glassfish-4.1-web-b17-09_16_2015.zip
-  - unzip -q glassfish41.zip
+  - curl -s -o glassfish5.zip http://download.oracle.com/glassfish/5.0/promoted/latest-web.zip
+  - unzip -q glassfish5.zip
 script:
   - ./.travis-build.sh ${TYPE}
 after_success:


### PR DESCRIPTION
I updated the Glassfish version to use for the integration tests to the latest promoted build of Glassfish 5. Looking forward to see whether the integration tests still pass. ;-)