### PR TITLE
Replaced Jersey-specific feature-discovery logic by common JAX-RS implementation

### DIFF
--- a/ozark/src/main/java/org/glassfish/ozark/servlet/OzarkContainerInitializer.java
+++ b/ozark/src/main/java/org/glassfish/ozark/servlet/OzarkContainerInitializer.java
@@ -30,11 +30,12 @@ import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
 import static org.glassfish.ozark.util.AnnotationUtils.hasAnnotationOnClassOrMethod;
 
 /**
- * Initializes the Mvc class with the application and context path. Note that the
+ * Initializes the MVC class with the application and context path. Note that the
  * application path is only initialized if there is an application sub-class that
  * is annotated by {@link javax.ws.rs.ApplicationPath}.
  *
  * @author Santiago Pericas-Geertsen
+ * @author Dmytro Maidaniuk
  */
 @HandlesTypes({ ApplicationPath.class, Path.class })
 public class OzarkContainerInitializer implements ServletContainerInitializer {
@@ -60,6 +61,10 @@ public class OzarkContainerInitializer implements ServletContainerInitializer {
                 if (hasAnnotationOnClassOrMethod(clazz, Path.class) 
                         && hasAnnotationOnClassOrMethod(clazz, Controller.class)) {
                     servletContext.setAttribute(OZARK_ENABLE_FEATURES_KEY, true);
+                }
+                if (servletContext.getAttribute(APP_PATH_CONTEXT_KEY) != null && 
+                        (Boolean)servletContext.getAttribute(OZARK_ENABLE_FEATURES_KEY) == true) {
+                    break;  // no need to loop further
                 }
             }
         }

--- a/ozark/src/main/java/org/glassfish/ozark/servlet/OzarkContainerInitializer.java
+++ b/ozark/src/main/java/org/glassfish/ozark/servlet/OzarkContainerInitializer.java
@@ -21,8 +21,13 @@ import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 import javax.ws.rs.ApplicationPath;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.mvc.annotation.Controller;
+import javax.ws.rs.Path;
 
 import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
+import static org.glassfish.ozark.util.AnnotationUtils.hasAnnotationOnClassOrMethod;
 
 /**
  * Initializes the Mvc class with the application and context path. Note that the
@@ -31,19 +36,33 @@ import static org.glassfish.ozark.util.AnnotationUtils.getAnnotation;
  *
  * @author Santiago Pericas-Geertsen
  */
-@HandlesTypes({ ApplicationPath.class })
+@HandlesTypes({ ApplicationPath.class, Path.class })
 public class OzarkContainerInitializer implements ServletContainerInitializer {
 
     public static final String APP_PATH_CONTEXT_KEY = OzarkContainerInitializer.class.getName() + ".APP_PATH";
+    public static final String OZARK_ENABLE_FEATURES_KEY = "ozark.enableFeatures";
+    private static final Logger LOG = Logger.getLogger(OzarkContainerInitializer.class.getName());
 
     @Override
     public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
+        servletContext.setAttribute(OZARK_ENABLE_FEATURES_KEY, false);
         if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                servletContext.setAttribute(APP_PATH_CONTEXT_KEY, ap.value());
+            LOG.log(Level.INFO, "Ozark version {0} started", getClass().getPackage().getImplementationVersion());
+            for (Class<?> clazz : classes) {
+                final ApplicationPath ap = getAnnotation(clazz, ApplicationPath.class);
+                if (ap != null) {
+                    if (servletContext.getAttribute(APP_PATH_CONTEXT_KEY) != null) {
+                        // must be a singleton
+                        throw new IllegalStateException("More than one JAX-RS ApplicationPath detected!");
+                    }
+                    servletContext.setAttribute(APP_PATH_CONTEXT_KEY, ap.value());
+                }
+                if (hasAnnotationOnClassOrMethod(clazz, Path.class) 
+                        && hasAnnotationOnClassOrMethod(clazz, Controller.class)) {
+                    servletContext.setAttribute(OZARK_ENABLE_FEATURES_KEY, true);
+                }
             }
         }
     }
+
 }

--- a/ozark/src/main/java/org/glassfish/ozark/util/AnnotationUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/util/AnnotationUtils.java
@@ -148,6 +148,20 @@ public final class AnnotationUtils {
     }
 
     /**
+     * Determines if an annotation is present on a class or its methods by calling
+     * {@link #getAnnotation(Class, Class)} and {@link #getAnnotation(java.lang.reflect.Method, Class)} iteratively.
+     *
+     * @param <T> the type.
+     * @param clazz class to search annotation.
+     * @param annotationType type of annotation to search for.
+     * @return outcome of test.
+     */
+    public static <T extends Annotation> boolean hasAnnotationOnClassOrMethod(Class<?> clazz, Class<T> annotationType) {
+        return hasAnnotation(clazz, annotationType)
+                || Arrays.stream(clazz.getMethods()).anyMatch(m -> hasAnnotation(m, annotationType));
+    }
+
+    /**
      * Determines if a method has one or more MVC or JAX-RS annotations on it.
      *
      * @param method method to check for MVC or JAX-RS annotations.

--- a/ozark/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable
+++ b/ozark/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable
@@ -1,1 +1,0 @@
-org.glassfish.ozark.jersey.OzarkFeature


### PR DESCRIPTION
Ozark is implemented using a number of JAX-RS providers (like a MessageBodyWriter, ContainerRequestFilter, ContainerResponseFilter, etc). These providers are registered with the JAX-RS runtime using a Jersey specific SPIs called AutoDiscoverable/ForcedAutoDiscoverable. However, this custom registration process not supported by other JAX-RS implementations, e.g RESTEasy. Thus we need to re-implement Ozark features discovery in a vendor-independent way.