### PR TITLE
updated jade4j to 1.2.5 version

### DIFF
--- a/ext/jade/pom.xml
+++ b/ext/jade/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>de.neuland-bfi</groupId>
             <artifactId>jade4j</artifactId>
-            <version>0.4.3</version>
+            <version>1.2.5</version>
         </dependency>
     </dependencies>
     <properties>

--- a/test/jade/src/main/java/org/glassfish/ozark/test/jade/DummyFilter.java
+++ b/test/jade/src/main/java/org/glassfish/ozark/test/jade/DummyFilter.java
@@ -16,6 +16,8 @@
 package org.glassfish.ozark.test.jade;
 
 import de.neuland.jade4j.filter.Filter;
+import de.neuland.jade4j.parser.node.Attr;
+import java.util.List;
 
 import java.util.Map;
 
@@ -27,7 +29,7 @@ import java.util.Map;
 public class DummyFilter implements Filter {
 
     @Override
-    public String convert(String source, Map<String, Object> attributes, Map<String, Object> model) {
+    public String convert(String source, List<Attr> attributes, Map<String, Object> model) {
         String content = source.trim();
         return String.format("<p class='%s'>%s</p>", content, content);
     }


### PR DESCRIPTION
Minor commit to allow usage of some newer jade4j features. 
This will also remove the need to manually exclude old version of jade4j from ozark-jade extension dependency and adding a new one explicitly for users who want to use newer jade4j features.