### PR TITLE
Updating Jersey to 2.26-b07

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     </modules>
     <properties>
         <spec.version>1.0-SNAPSHOT</spec.version>
-        <jersey.version>2.21.1</jersey.version>
+        <jersey.version>2.26-b07</jersey.version>
     </properties>
     <reporting>
         <excludeDefaults>true</excludeDefaults>


### PR DESCRIPTION
This PR updates Jersey to the latest version. This is especially important, because this Jersey version fixes the following issue:

https://github.com/jersey/jersey/issues/3582