### PR TITLE
Use Glassfish nightly builds for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - TYPE=glassfish-bundled
 install:
   - mvn dependency:get -Dartifact=javax.mvc:javax.mvc-api:1.0-SNAPSHOT -DremoteRepositories=central::default::https://repo1.maven.org/maven2,javanet::default::https://maven.java.net/content/repositories/snapshots
-  - curl -s -o glassfish5.zip http://download.oracle.com/glassfish/5.0/promoted/latest-web.zip
+  - curl -s -o glassfish5.zip http://download.oracle.com/glassfish/5.0/nightly/latest-web.zip
   - unzip -q glassfish5.zip
 script:
   - ./.travis-build.sh ${TYPE}


### PR DESCRIPTION
As Jersey starts to address some of the issues we reported, it makes sense to execute the integration tests against the Glassfish Nightly Builds. This way we get the new Jersey versions as early as possible.

For example: https://github.com/jersey/jersey/issues/3582

The new Jersey version which fixes this issue is available in the nightly but not yet in the promoted build.