### PR TITLE
Back to older Glassfish 5 nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - TYPE=glassfish-bundled
 install:
   - mvn dependency:get -Dartifact=javax.mvc:javax.mvc-api:1.0-SNAPSHOT -DremoteRepositories=central::default::https://repo1.maven.org/maven2,javanet::default::https://maven.java.net/content/repositories/snapshots
-  - curl -s -o glassfish5.zip http://download.oracle.com/glassfish/5.0/promoted/latest-web.zip
+  - curl -s -o glassfish5.zip http://download.oracle.com/glassfish/5.0/nightly/glassfish-5.0-web-b10-06_29_2017.zip
   - unzip -q glassfish5.zip
 script:
   - ./.travis-build.sh ${TYPE}


### PR DESCRIPTION
Back to an older Glassfish 5 build which doesn't break `BindingInterceptorImpl`...