### PR TITLE
Removed dependency:get from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   - TYPE=glassfish-module
   - TYPE=glassfish-bundled
 install:
-  - mvn dependency:get -Dartifact=javax.mvc:javax.mvc-api:1.0-SNAPSHOT -DremoteRepositories=central::default::https://repo1.maven.org/maven2,javanet::default::https://maven.java.net/content/repositories/snapshots
   - curl -s -o glassfish5.zip http://download.oracle.com/glassfish/5.0/nightly/glassfish-5.0-web-b10-06_29_2017.zip
   - unzip -q glassfish5.zip
 script:


### PR DESCRIPTION
I removed a command which basically fetched the latest mvc-api snaphots from the old java.net Maven repo. I don't think that this is necessary any more, because Travis already supports the Sonatype snapshots repo.