### PR TITLE
Updated groupId to "org.mvc-spec.ozark"

### DIFF
--- a/ext/asciidoc/pom.xml
+++ b/ext/asciidoc/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/freemarker/pom.xml
+++ b/ext/freemarker/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/handlebars/pom.xml
+++ b/ext/handlebars/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/jade/pom.xml
+++ b/ext/jade/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/jsr223/pom.xml
+++ b/ext/jsr223/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/mustache/pom.xml
+++ b/ext/mustache/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/pebble/pom.xml
+++ b/ext/pebble/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -19,11 +19,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark</groupId>
+        <groupId>org.mvc-spec.ozark</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
-    <groupId>org.glassfish.ozark.ext</groupId>
+    <groupId>org.mvc-spec.ozark.ext</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
     <name>Ozark ${project.version} Extensions</name>
@@ -35,7 +35,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.ozark</groupId>
+            <groupId>org.mvc-spec.ozark</groupId>
             <artifactId>ozark</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
             <scope>provided</scope>

--- a/ext/stringtemplate/pom.xml
+++ b/ext/stringtemplate/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/thymeleaf/pom.xml
+++ b/ext/thymeleaf/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ext/velocity/pom.xml
+++ b/ext/velocity/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.ext</groupId>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/ozark/pom.xml
+++ b/ozark/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark</groupId>
+        <groupId>org.mvc-spec.ozark</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -250,7 +250,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <api_package>javax.mvc</api_package>
-        <impl_namespace>org.glassfish.ozark</impl_namespace>
+        <impl_namespace>org.mvc-spec.ozark</impl_namespace>
 
         <spec_version>1.0</spec_version>
         <spec_impl_version>1.0-SNAPSHOT</spec_impl_version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.glassfish.ozark</groupId>
+    <groupId>org.mvc-spec.ozark</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
     <version>1.0.0-m03-SNAPSHOT</version>
@@ -38,7 +38,7 @@
     </properties>
     <reporting>
         <excludeDefaults>true</excludeDefaults>
-    </reporting>    
+    </reporting>
     <scm>
         <connection>scm:git:https://github.com/mvc-spec/ozark.git</connection>
         <developerConnection>scm:git:https://github.com/mvc-spec/ozark.git</developerConnection>

--- a/test/annotations/pom.xml
+++ b/test/annotations/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/application-path/pom.xml
+++ b/test/application-path/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/asciidoc/pom.xml
+++ b/test/asciidoc/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-asciidoc</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/book-cdi/pom.xml
+++ b/test/book-cdi/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/book-models/pom.xml
+++ b/test/book-models/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/conversation/pom.xml
+++ b/test/conversation/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/csrf-property/pom.xml
+++ b/test/csrf-property/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -31,7 +31,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark</groupId>
+            <groupId>org.mvc-spec.ozark</groupId>
             <artifactId>ozark</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>

--- a/test/csrf/pom.xml
+++ b/test/csrf/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -31,7 +31,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark</groupId>
+            <groupId>org.mvc-spec.ozark</groupId>
             <artifactId>ozark</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>

--- a/test/events/pom.xml
+++ b/test/events/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -33,7 +33,7 @@
     <dependencies>
         <!-- Access Ozark's extended MVC events -->
         <dependency>
-            <groupId>org.glassfish.ozark</groupId>
+            <groupId>org.mvc-spec.ozark</groupId>
             <artifactId>ozark</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/exceptions/pom.xml
+++ b/test/exceptions/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/facelets/pom.xml
+++ b/test/facelets/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/freemarker/pom.xml
+++ b/test/freemarker/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-freemarker</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/handlebars/pom.xml
+++ b/test/handlebars/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -31,7 +31,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-handlebars</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/jade/pom.xml
+++ b/test/jade/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-jade</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/test/jsr223/pom.xml
+++ b/test/jsr223/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-jsr223</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/locale/pom.xml
+++ b/test/locale/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/mustache/pom.xml
+++ b/test/mustache/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-mustache</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/mvc/pom.xml
+++ b/test/mvc/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -31,7 +31,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark</groupId>
+            <groupId>org.mvc-spec.ozark</groupId>
             <artifactId>ozark</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>

--- a/test/pebble/pom.xml
+++ b/test/pebble/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,12 +32,12 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-pebble</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.ozark</groupId>
+            <groupId>org.mvc-spec.ozark</groupId>
             <artifactId>ozark</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -20,11 +20,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark</groupId>
+        <groupId>org.mvc-spec.ozark</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
-    <groupId>org.glassfish.ozark.test</groupId>
+    <groupId>org.mvc-spec.ozark.test</groupId>
     <artifactId>parent</artifactId>
     <packaging>pom</packaging>
     <name>Ozark ${project.version} Integration Tests</name>
@@ -110,7 +110,7 @@
                     <scope>compile</scope>
                 </dependency>
                 <dependency>
-                    <groupId>org.glassfish.ozark</groupId>
+                    <groupId>org.mvc-spec.ozark</groupId>
                     <artifactId>ozark</artifactId>
                     <version>${project.version}</version>
                     <scope>runtime</scope>
@@ -396,7 +396,7 @@
                 <failOnError>false</failOnError>
                 <timeout>60</timeout>
             </properties>
-        </profile>    
+        </profile>
     </profiles>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/test/produces/pom.xml
+++ b/test/produces/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/redirect/pom.xml
+++ b/test/redirect/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/redirectScope/pom.xml
+++ b/test/redirectScope/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/redirectScope2/pom.xml
+++ b/test/redirectScope2/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -31,7 +31,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark</groupId>
+            <groupId>org.mvc-spec.ozark</groupId>
             <artifactId>ozark</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>

--- a/test/requestDispatcher/pom.xml
+++ b/test/requestDispatcher/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/returns/pom.xml
+++ b/test/returns/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/stringtemplate/pom.xml
+++ b/test/stringtemplate/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-stringtemplate</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/thymeleaf/pom.xml
+++ b/test/thymeleaf/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-thymeleaf</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/test/validation-i18n/pom.xml
+++ b/test/validation-i18n/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/validation/pom.xml
+++ b/test/validation/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>

--- a/test/velocity/pom.xml
+++ b/test/velocity/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
@@ -32,7 +32,7 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.ozark.ext</groupId>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
             <artifactId>ozark-velocity</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/test/view-annotation/pom.xml
+++ b/test/view-annotation/pom.xml
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.glassfish.ozark.test</groupId>
+        <groupId>org.mvc-spec.ozark.test</groupId>
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
This PR updated the Maven group-id to "org.mvc-spec.ozark" which is the new group-id we will use for publishing to Maven Central.