### PR TITLE
Update Maven module artifactIds

### DIFF
--- a/ext/asciidoc/pom.xml
+++ b/ext/asciidoc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-asciidoc</artifactId>

--- a/ext/freemarker/pom.xml
+++ b/ext/freemarker/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-freemarker</artifactId>

--- a/ext/handlebars/pom.xml
+++ b/ext/handlebars/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-handlebars</artifactId>

--- a/ext/jade/pom.xml
+++ b/ext/jade/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-jade</artifactId>

--- a/ext/jsr223/pom.xml
+++ b/ext/jsr223/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-jsr223</artifactId>

--- a/ext/mustache/pom.xml
+++ b/ext/mustache/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-mustache</artifactId>

--- a/ext/pebble/pom.xml
+++ b/ext/pebble/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-pebble</artifactId>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -20,13 +20,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <groupId>org.mvc-spec.ozark.ext</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>ozark-parent-ext</artifactId>
     <packaging>pom</packaging>
-    <name>Ozark ${project.version} Extensions</name>
+    <name>Ozark ${project.version} Extensions Parent</name>
     <dependencies>
         <dependency>
             <groupId>javax.mvc</groupId>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.mvc-spec.ozark</groupId>
-            <artifactId>ozark</artifactId>
+            <artifactId>ozark-core</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/ext/stringtemplate/pom.xml
+++ b/ext/stringtemplate/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-stringtemplate</artifactId>

--- a/ext/thymeleaf/pom.xml
+++ b/ext/thymeleaf/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-thymeleaf</artifactId>

--- a/ext/velocity/pom.xml
+++ b/ext/velocity/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.ext</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-ext</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-velocity</artifactId>

--- a/ozark/pom.xml
+++ b/ozark/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>ozark-core</artifactId>

--- a/ozark/pom.xml
+++ b/ozark/pom.xml
@@ -24,9 +24,9 @@
         <artifactId>parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
-    <artifactId>ozark</artifactId>
+    <artifactId>ozark-core</artifactId>
     <packaging>bundle</packaging>
-    <name>Ozark ${project.version} MVC RI</name>
+    <name>Ozark ${project.version} Core</name>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mvc-spec.ozark</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>ozark-parent</artifactId>
     <packaging>pom</packaging>
     <version>1.0.0-m03-SNAPSHOT</version>
-    <name>Ozark ${project.version} Parent Project</name>
+    <name>Ozark ${project.version} Parent</name>
     <parent>
         <groupId>net.java</groupId>
         <artifactId>jvnet-parent</artifactId>

--- a/test/annotations/pom.xml
+++ b/test/annotations/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>annotations</artifactId>

--- a/test/application-path/pom.xml
+++ b/test/application-path/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>application-path</artifactId>

--- a/test/asciidoc/pom.xml
+++ b/test/asciidoc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>asciidoc</artifactId>

--- a/test/book-cdi/pom.xml
+++ b/test/book-cdi/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>book-cdi</artifactId>

--- a/test/book-models/pom.xml
+++ b/test/book-models/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>book-models</artifactId>

--- a/test/conversation/pom.xml
+++ b/test/conversation/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>conversation</artifactId>

--- a/test/csrf-property/pom.xml
+++ b/test/csrf-property/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>csrf-property</artifactId>

--- a/test/csrf-property/pom.xml
+++ b/test/csrf-property/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>org.mvc-spec.ozark</groupId>
-            <artifactId>ozark</artifactId>
+            <artifactId>ozark-core</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/test/csrf/pom.xml
+++ b/test/csrf/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>org.mvc-spec.ozark</groupId>
-            <artifactId>ozark</artifactId>
+            <artifactId>ozark-core</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/test/csrf/pom.xml
+++ b/test/csrf/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>csrf</artifactId>

--- a/test/events/pom.xml
+++ b/test/events/pom.xml
@@ -34,7 +34,7 @@
         <!-- Access Ozark's extended MVC events -->
         <dependency>
             <groupId>org.mvc-spec.ozark</groupId>
-            <artifactId>ozark</artifactId>
+            <artifactId>ozark-core</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/test/events/pom.xml
+++ b/test/events/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>events</artifactId>

--- a/test/exceptions/pom.xml
+++ b/test/exceptions/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>exceptions</artifactId>

--- a/test/facelets/pom.xml
+++ b/test/facelets/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>facelets</artifactId>

--- a/test/freemarker/pom.xml
+++ b/test/freemarker/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>freemarker</artifactId>

--- a/test/handlebars/pom.xml
+++ b/test/handlebars/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>handlebars</artifactId>

--- a/test/jade/pom.xml
+++ b/test/jade/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>jade</artifactId>

--- a/test/jsr223/pom.xml
+++ b/test/jsr223/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>jsr223</artifactId>

--- a/test/locale/pom.xml
+++ b/test/locale/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>locale</artifactId>

--- a/test/mustache/pom.xml
+++ b/test/mustache/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>mustache</artifactId>

--- a/test/mvc/pom.xml
+++ b/test/mvc/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>mvc</artifactId>

--- a/test/mvc/pom.xml
+++ b/test/mvc/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>org.mvc-spec.ozark</groupId>
-            <artifactId>ozark</artifactId>
+            <artifactId>ozark-core</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/test/pebble/pom.xml
+++ b/test/pebble/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>pebble</artifactId>

--- a/test/pebble/pom.xml
+++ b/test/pebble/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>org.mvc-spec.ozark</groupId>
-            <artifactId>ozark</artifactId>
+            <artifactId>ozark-core</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,13 +21,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <groupId>org.mvc-spec.ozark.test</groupId>
-    <artifactId>parent</artifactId>
+    <artifactId>ozark-parent-test</artifactId>
     <packaging>pom</packaging>
-    <name>Ozark ${project.version} Integration Tests</name>
+    <name>Ozark ${project.version} Integration Tests Parent</name>
     <build>
         <plugins>
             <plugin>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -111,7 +111,7 @@
                 </dependency>
                 <dependency>
                     <groupId>org.mvc-spec.ozark</groupId>
-                    <artifactId>ozark</artifactId>
+                    <artifactId>ozark-core</artifactId>
                     <version>${project.version}</version>
                     <scope>runtime</scope>
                 </dependency>

--- a/test/produces/pom.xml
+++ b/test/produces/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>produces</artifactId>

--- a/test/redirect/pom.xml
+++ b/test/redirect/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>redirect</artifactId>

--- a/test/redirectScope/pom.xml
+++ b/test/redirectScope/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>redirectScope</artifactId>

--- a/test/redirectScope2/pom.xml
+++ b/test/redirectScope2/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>redirectScope2</artifactId>

--- a/test/redirectScope2/pom.xml
+++ b/test/redirectScope2/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>org.mvc-spec.ozark</groupId>
-            <artifactId>ozark</artifactId>
+            <artifactId>ozark-core</artifactId>
             <version>1.0.0-m03-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/test/requestDispatcher/pom.xml
+++ b/test/requestDispatcher/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>requestDispatcher</artifactId>

--- a/test/returns/pom.xml
+++ b/test/returns/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>returns</artifactId>

--- a/test/stringtemplate/pom.xml
+++ b/test/stringtemplate/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>stringtemplate</artifactId>

--- a/test/thymeleaf/pom.xml
+++ b/test/thymeleaf/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>thymeleaf</artifactId>

--- a/test/validation-i18n/pom.xml
+++ b/test/validation-i18n/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>validation-i18n</artifactId>

--- a/test/validation/pom.xml
+++ b/test/validation/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>validation</artifactId>

--- a/test/velocity/pom.xml
+++ b/test/velocity/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>velocity</artifactId>

--- a/test/view-annotation/pom.xml
+++ b/test/view-annotation/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.mvc-spec.ozark.test</groupId>
-        <artifactId>parent</artifactId>
+        <artifactId>ozark-parent-test</artifactId>
         <version>1.0.0-m03-SNAPSHOT</version>
     </parent>
     <artifactId>view-annotation</artifactId>


### PR DESCRIPTION
This PR is a first step to restructure the Maven modules of Ozark. It contains the following two commits:

* The module `ozark` is renamed to `ozark-core`. This allows us to add additional modules `ozark-jersey` and `ozark-resteasy` later on which will contain the JAX-RS implementation specific code.
* Currently all the parent POM artifactIds are `parent` which is a bit confusing as you usually only see the artifactId of a module in your IDE. I renamed the artifactIds to `ozark-parent`, `ozark-parent-ext` and `ozark-parent-test` to fix this.

I hope everyone agrees with these changes. Let me know if you have any objections.