### PR TITLE
Implement MvcUriBuilder

### DIFF
--- a/ozark/src/main/java/org/glassfish/ozark/MvcContextImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/MvcContextImpl.java
@@ -17,6 +17,7 @@ package org.glassfish.ozark;
 
 import org.glassfish.ozark.jaxrs.JaxRsContext;
 import org.glassfish.ozark.servlet.OzarkContainerInitializer;
+import org.glassfish.ozark.uri.ApplicationUris;
 import org.glassfish.ozark.util.PathUtils;
 
 import javax.annotation.PostConstruct;
@@ -55,6 +56,9 @@ public class MvcContextImpl implements MvcContext {
 
     @Inject
     private ServletContext servletContext;
+
+    @Inject
+    private ApplicationUris applicationUris;
 
     @Inject
     @JaxRsContext
@@ -124,23 +128,23 @@ public class MvcContextImpl implements MvcContext {
     }
 
     @Override
-    public URI uri(String s) {
+    public URI uri(String identifier) {
+        return applicationUris.get(identifier);
+    }
+
+    @Override
+    public URI uri(String identifier, Map<String, Object> params) {
+        return applicationUris.get(identifier, params);
+    }
+
+    @Override
+    public URI uri(String identifier, List<Object> params) {
         throw new UnsupportedOperationException("Not implemented yet!");
     }
 
     @Override
-    public URI uri(String s, List<Object> list) {
-        throw new UnsupportedOperationException("Not implemented yet!");
-    }
-
-    @Override
-    public URI uri(String s, Map<String, Object> map) {
-        throw new UnsupportedOperationException("Not implemented yet!");
-    }
-
-    @Override
-    public MvcUriBuilder uriBuilder(String s) {
-        throw new UnsupportedOperationException("Not implemented yet!");
+    public MvcUriBuilder uriBuilder(String identifier) {
+        return applicationUris.getUriBuilder(identifier);
     }
 
 }

--- a/ozark/src/main/java/org/glassfish/ozark/cdi/OzarkCdiExtension.java
+++ b/ozark/src/main/java/org/glassfish/ozark/cdi/OzarkCdiExtension.java
@@ -33,6 +33,8 @@ import org.glassfish.ozark.security.CsrfImpl;
 import org.glassfish.ozark.security.CsrfProtectFilter;
 import org.glassfish.ozark.security.CsrfValidateInterceptor;
 import org.glassfish.ozark.security.EncodersImpl;
+import org.glassfish.ozark.uri.ApplicationUris;
+import org.glassfish.ozark.uri.UriTemplateParser;
 import org.glassfish.ozark.util.CdiUtils;
 
 import javax.enterprise.event.Observes;
@@ -118,7 +120,11 @@ public class OzarkCdiExtension implements Extension {
 
                 // jaxrs
                 JaxRsContextFilter.class,
-                JaxRsContextProducer.class
+                JaxRsContextProducer.class,
+
+                // uri
+                ApplicationUris.class,
+                UriTemplateParser.class
 
         );
     }

--- a/ozark/src/main/java/org/glassfish/ozark/uri/ApplicationUris.java
+++ b/ozark/src/main/java/org/glassfish/ozark/uri/ApplicationUris.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import org.glassfish.ozark.util.AnnotationUtils;
+
+import javax.enterprise.inject.Vetoed;
+import javax.mvc.MvcUriBuilder;
+import javax.mvc.annotation.UriRef;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * <p>A cache for all parsed instances of {@link UriTemplate}
+ * providing methods to generate URIs of current application.</p>
+ *
+ * @author Florian Hirsch
+ */
+@Vetoed // produced by UriTemplateParser
+public class ApplicationUris {
+
+    private MultivaluedMap<String, UriTemplate> uriTemplates = new MultivaluedHashMap<>();
+
+    /**
+     * @see javax.mvc.MvcContext#uri(String)
+     */
+    public URI get(String identifier) {
+        return getUriBuilder(identifier).build();
+    }
+
+    /**
+     * @see javax.mvc.MvcContext#uri(String, Map)
+     */
+    public URI get(String identifier, Map<String, Object> params) {
+        MvcUriBuilder uriBuilder = getUriBuilder(identifier);
+        params.forEach(uriBuilder::param);
+        return uriBuilder.build();
+    }
+
+    /**
+     * @see javax.mvc.MvcContext#uriBuilder(String)
+     */
+    public MvcUriBuilder getUriBuilder(String identifier) {
+        return new DefaultMvcUriBuilder(getUriTemplate(identifier));
+    }
+
+    /**
+     * <p>Registers given uriTemplate by the value of
+     * the {@link UriRef} annotation if present on given method
+     * <em>and</em> by the simple name of the controller class
+     * and the method name separated by '#' (MyController#myMethod).</p>
+     *
+     * <p>We don't validate ambigous usage of e.g. MyController#myMethod as this
+     * is valid if mvc#uri methods are not used.</p>
+     */
+    void register(UriTemplate uriTemplate, Method method) {
+        UriRef uriRef = AnnotationUtils.getAnnotation(method, UriRef.class);
+        if (uriRef != null) {
+            merge(uriRef.value(), uriTemplate);
+        }
+        String identifier = String.format("%s#%s", method.getDeclaringClass().getSimpleName(), method.getName());
+        merge(identifier, uriTemplate);
+    }
+
+    /**
+     * <p>Merges given UriTemplate into the Cache.
+     * If one or more templates for given identifier is found
+     * we check if the exisiting templates have the same path.
+     * If so we merge the optional query- and matrix params to the template.
+     * It's valid to reuse an identifier for the same path for different HTTP methods.
+     * If the pathes don't match the usage of the identifier is amigous and
+     * we store both templates to inform the developer about all invalid usages.</p>
+     */
+    private void merge(String identifier, UriTemplate uriTemplate) {
+        if (!uriTemplates.containsKey(identifier)) {
+            uriTemplates.add(identifier, uriTemplate);
+            return;
+        }
+        Optional<UriTemplate> existingTemplate = uriTemplates.get(identifier).stream().filter(template
+            -> template.path().equals(uriTemplate.path())).findFirst();
+        if (existingTemplate.isPresent()) {
+            UriTemplate template = existingTemplate.get();
+            template.queryParams().addAll(uriTemplate.queryParams());
+            template.matrixParams().addAll(uriTemplate.matrixParams());
+        } else {
+            uriTemplates.add(identifier, uriTemplate);
+        }
+    }
+
+    /**
+     * @return the UriTemplate for given identifier from the cache.
+     * @throws IllegalArgumentException if no UriTemplate
+     * is found for given identifier or if ambiguously used
+     * templates are found.
+     */
+    private UriTemplate getUriTemplate(String identifier) {
+        Objects.requireNonNull(identifier, "identifier must not be null");
+        if (!uriTemplates.containsKey(identifier)) {
+            throw new IllegalArgumentException(
+                String.format("No uriTemplate registered for identifier '%s'", identifier));
+        }
+        List<UriTemplate> registeredTemplats = uriTemplates.get(identifier);
+        if (registeredTemplats.size() > 1) {
+            throw new IllegalArgumentException(String.format(
+                "Ambiguous usage of identifier '%s' for following URIs: %s", identifier,
+                registeredTemplats.stream().map(UriTemplate::path).collect(Collectors.toList())));
+        }
+        return this.uriTemplates.getFirst(identifier);
+    }
+
+    /**
+     * @return all registered UriTemplates with their identifier.
+     */
+    Set<Map.Entry<String, List<UriTemplate>>> list() {
+        return uriTemplates.entrySet();
+    }
+
+    @Override
+    public String toString() {
+        return "ApplicationUris{" + "uriTemplates=" + uriTemplates + '}';
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/uri/DefaultMvcUriBuilder.java
+++ b/ozark/src/main/java/org/glassfish/ozark/uri/DefaultMvcUriBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import javax.mvc.MvcUriBuilder;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * <p>Default implementation of {@link MvcUriBuilder}.</p>
+ *
+ * @author Florian Hirsch
+ */
+class DefaultMvcUriBuilder implements MvcUriBuilder {
+
+    private final UriTemplate uriTemplate;
+
+    private MultivaluedMap<String, Object> parameters = new MultivaluedHashMap<>();
+
+    DefaultMvcUriBuilder(UriTemplate UriTemplate) {
+        Objects.requireNonNull(UriTemplate, "uriTemplate must not be null");
+        this.uriTemplate = UriTemplate;
+    }
+
+    @Override
+    public MvcUriBuilder param(String name, Object... values) {
+        Objects.requireNonNull(values, "name must not be null");
+        Objects.requireNonNull(values, "values must not be null");
+        Arrays.stream(values).forEach(value -> {
+            // ensure that an Iterable is not interpreted as one Object
+            Iterable<Object> vals = value instanceof Iterable
+                ? (Iterable) value : Collections.singleton(value);
+            vals.forEach(val -> parameters.add(name, val));
+        });
+        return this;
+    }
+
+    @Override
+    public URI build() {
+        UriBuilder uriBuilder = UriBuilder.fromUri(uriTemplate.path());
+        Map<String, Object> pathParams = new HashMap<>();
+        // Everything which is not defined as query- or matrix-param should
+        // be a path-param and appear only once
+        parameters.forEach((key, value) -> {
+            if (uriTemplate.queryParams().contains(key)) {
+                value.forEach(val -> uriBuilder.queryParam(key, val));
+            } else if (uriTemplate.matrixParams().contains(key)) {
+                value.forEach(val -> uriBuilder.matrixParam(key, val));
+            } else {
+                // won't allow different values for the same path identifier
+                pathParams.put(key, value.get(0));
+            }
+        });
+        return uriBuilder.buildFromMap(pathParams);
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/uri/UriTemplate.java
+++ b/ozark/src/main/java/org/glassfish/ozark/uri/UriTemplate.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * <p>Encapsulates an URI-template and query- and matrix parameters.</p>
+ *
+ * @author Florian Hirsch
+ */
+public class UriTemplate {
+
+    private final String path;
+
+    private final Set<String> queryParams;
+
+    private final Set<String> matrixParams;
+
+    private UriTemplate(String path, Set<String> queryParams, Set<String> matrixParams) {
+        this.path = path;
+        this.queryParams = queryParams;
+        this.matrixParams = matrixParams;
+    }
+
+    static Builder fromTemplate(String template) {
+        return new Builder(template);
+    }
+
+    public String path() {
+        return path;
+    }
+
+    Set<String> queryParams() {
+        return queryParams;
+    }
+
+    Set<String> matrixParams() {
+        return matrixParams;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        UriTemplate that = (UriTemplate) other;
+        return Objects.equals(path, that.path) &&
+            Objects.equals(queryParams, that.queryParams) &&
+            Objects.equals(matrixParams, that.matrixParams);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, queryParams, matrixParams);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("UriTemplate { path: %s, queryParams: %s, matrixParams: %s }",
+            path, queryParams, matrixParams);
+    }
+
+    /**
+     * <p>Builder for a UriTemplate.</p>
+     */
+    static class Builder {
+
+        private String path;
+
+        private Set<String> queryParams;
+
+        private Set<String> matrixParams;
+
+        Builder(String path) {
+            Objects.requireNonNull(path, "path must not be null");
+            this.path = path;
+        }
+
+        Builder queryParam(String queryParam) {
+            if (queryParams == null) {
+                queryParams = new HashSet<>();
+            }
+            queryParams.add(queryParam);
+            return this;
+        }
+
+        Builder matrixParam(String matrixParam) {
+            if (matrixParams == null) {
+                matrixParams = new HashSet<>();
+            }
+            matrixParams.add(matrixParam);
+            return this;
+        }
+
+        UriTemplate build() {
+            return new UriTemplate(path,
+                queryParams == null ? Collections.emptySet() : queryParams,
+                matrixParams == null ? Collections.emptySet() : matrixParams);
+        }
+
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/uri/UriTemplateParser.java
+++ b/ozark/src/main/java/org/glassfish/ozark/uri/UriTemplateParser.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import org.glassfish.ozark.util.AnnotationUtils;
+import org.glassfish.ozark.util.BeanUtils;
+import org.glassfish.ozark.util.ControllerUtils;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.mvc.MvcContext;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.MatrixParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriBuilder;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * <p>Parses all instances of {@link UriTemplate} and @Produces
+ * the {@link ApplicationUris}.</p>
+ *
+ * @author Florian Hirsch
+ */
+@ApplicationScoped
+public class UriTemplateParser {
+
+    @Inject
+    MvcContext mvcContext;
+
+    @Context
+    Application application;
+
+    @Produces @ApplicationScoped
+    private ApplicationUris applicationUris;
+
+    @PostConstruct
+    public void init() {
+        applicationUris = init(controllers());
+    }
+
+    ApplicationUris init(Set<Class<?>> controllers) {
+        ApplicationUris uris = new ApplicationUris();
+        controllers.forEach(controller ->
+            Stream.of(controller.getMethods()).filter(ControllerUtils::isControllerMethod).forEach(method -> {
+                UriTemplate uriTemplate = parseMethod(method, mvcContext.getBasePath());
+                uris.register(uriTemplate, method);
+            })
+        );
+        return uris;
+    }
+
+    /**
+     * <p>Parses given method and constructs a {@link UriTemplate} containing
+     * all the information found in the annotations {@link javax.ws.rs.Path},
+     * {@link javax.ws.rs.QueryParam} and {@link javax.ws.rs.MatrixParam}.</p>
+     */
+    UriTemplate parseMethod(Method method, String basePath) {
+        UriBuilder uriBuilder = UriBuilder.fromPath(basePath);
+        Path controllerPath = AnnotationUtils.getAnnotation(method.getDeclaringClass(), Path.class);
+        if (controllerPath != null) {
+            uriBuilder.path(controllerPath.value());
+        }
+        Path methodPath = AnnotationUtils.getAnnotation(method, Path.class);
+        if (methodPath != null) {
+            uriBuilder.path(methodPath.value());
+        }
+        UriTemplate.Builder uriTemplateBuilder = UriTemplate.fromTemplate(uriBuilder.toTemplate());
+        // Populate a List with all properties of given target and all parameters of given method
+        // except for BeanParams where we need all properties of annotated type.
+        List<AnnotatedElement> annotatedElements = BeanUtils.getFieldsAndAccessors(method.getDeclaringClass());
+        Arrays.asList(method.getParameters()).forEach(param -> {
+            if (param.isAnnotationPresent(BeanParam.class)) {
+                annotatedElements.addAll(BeanUtils.getFieldsAndAccessors(param.getType()));
+            } else {
+                annotatedElements.add(param);
+            }
+        });
+        annotatedElements.forEach(accessibleObject -> {
+            if (accessibleObject.isAnnotationPresent(QueryParam.class)) {
+                uriTemplateBuilder.queryParam(accessibleObject.getAnnotation(QueryParam.class).value());
+            }
+            if (accessibleObject.isAnnotationPresent(MatrixParam.class)) {
+                uriTemplateBuilder.matrixParam(accessibleObject.getAnnotation(MatrixParam.class).value());
+            }
+        });
+        return uriTemplateBuilder.build();
+    }
+
+    private Set<Class<?>> controllers() {
+        return Stream.concat( //
+            application.getClasses().stream(), //
+            application.getSingletons().stream().map(Object::getClass)) //
+            .filter(ControllerUtils::isController) //
+            .collect(Collectors.toSet()); //
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/util/AnnotationUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/util/AnnotationUtils.java
@@ -153,7 +153,7 @@ public final class AnnotationUtils {
      * @param method method to check for MVC or JAX-RS annotations.
      * @return outcome of test.
      */
-    private static boolean hasMvcOrJaxrsAnnotations(Method method) {
+    static boolean hasMvcOrJaxrsAnnotations(Method method) {
         return Arrays.stream(method.getDeclaredAnnotations()).anyMatch(a -> {
             final String an = a.annotationType().getName();
             return an.startsWith("javax.mvc.") || an.startsWith("javax.ws.rs.");

--- a/ozark/src/main/java/org/glassfish/ozark/util/BeanUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/util/BeanUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.util;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for Bean related tasks
+ *
+ * @author Florian Hirsch
+ */
+public final class BeanUtils {
+
+    private BeanUtils() {
+
+    }
+
+    /**
+     * @return a List of all fields and getters/setters of given class.
+     */
+    public static List<AnnotatedElement> getFieldsAndAccessors(Class<?> clazz) {
+        List<AnnotatedElement> properties = new ArrayList<>();
+        properties.addAll(Arrays.stream(clazz.getDeclaredFields()).filter(f -> !f.isSynthetic()).collect(Collectors.toList()));
+        try {
+            Arrays.asList(Introspector.getBeanInfo(clazz, Object.class).getPropertyDescriptors()).forEach(prop -> {
+                if (prop.getReadMethod() != null) {
+                    properties.add(prop.getReadMethod());
+                }
+                if (prop.getWriteMethod() != null) {
+                    properties.add(prop.getWriteMethod());
+                }
+            });
+        } catch (IntrospectionException ex) {
+            throw new IllegalArgumentException(String.format("Could not parse properties from class %s", clazz), ex);
+        }
+        return properties;
+    }
+
+}

--- a/ozark/src/main/java/org/glassfish/ozark/util/ControllerUtils.java
+++ b/ozark/src/main/java/org/glassfish/ozark/util/ControllerUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.util;
+
+import javax.mvc.annotation.Controller;
+import javax.ws.rs.HttpMethod;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * Utility class for controller related checks.
+ *
+ * @author Florian Hirsch
+ */
+public final class ControllerUtils {
+
+    private ControllerUtils() {
+
+    }
+
+    /**
+     * Tests if given class or any method of this class is annotated with @Controller.
+     * Following the inheritance rules defined by the JAX-RS and MVC specification.
+     */
+    public static boolean isController(Class<?> clazz) {
+        return AnnotationUtils.getAnnotation(clazz, Controller.class) != null ||
+            Arrays.stream(clazz.getMethods()).anyMatch(m -> AnnotationUtils.getAnnotation(m, Controller.class) != null);
+    }
+
+    /**
+     * Tests if given method is a controller and request method which is true
+     * if a {@link Controller} annotation is found on given method or the declaring class
+     * and if a {@link HttpMethod} annotated annotation is declared or inherited on this method.
+     */
+    public static boolean isControllerMethod(Method method) {
+        boolean isController = AnnotationUtils.getAnnotation(method.getDeclaringClass(), Controller.class) != null
+            || AnnotationUtils.getAnnotation(method, Controller.class) != null;
+        return isController && isRequestMethod(method);
+    }
+
+    /**
+     * Tests if a {@link HttpMethod} annotated annotation is declared or inherited on this method
+     * following the inheritance rules defined by the MVC specification. If an annotation is
+     * not defined on a method, check super methods along the class hierarchy first. If
+     * not found, then look at the interface hierarchy. Note that this method implements
+     * a depth-first search strategy.
+     */
+    static boolean isRequestMethod(Method method) {
+        if (hasDeclaredRequestMethodAnnotation(method)) {
+            return true;
+        }
+        // inheritance disabled if other MVC or JAX-RS annotations found
+        if (AnnotationUtils.hasMvcOrJaxrsAnnotations(method)) {
+            return false;
+        }
+        // check all super classes
+        Class<?> clazz = method.getDeclaringClass();
+        while (clazz != null) { // Object.class reached
+            try {
+                Method currentMethod = clazz.getMethod(method.getName(), method.getParameterTypes());
+                if (hasDeclaredRequestMethodAnnotation(currentMethod)) {
+                    return true;
+                }
+            } catch (NoSuchMethodException ignored) { // NOPMD ignore empty catch block
+                // falls through
+            }
+            clazz = clazz.getSuperclass();
+        }
+        // check all interfaces
+        for (Class<?> in : method.getDeclaringClass().getInterfaces()) {
+            try {
+                Method currentMethod = in.getMethod(method.getName(), method.getParameterTypes());
+                if (hasDeclaredRequestMethodAnnotation(currentMethod)) {
+                    return true;
+                }
+            } catch (NoSuchMethodException ignored) { // NOPMD ignore empty catch block
+                // falls through
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Tests if a {@link HttpMethod} annotated annotation is
+     * directly present on given method without checking inheritance.
+     */
+    static boolean hasDeclaredRequestMethodAnnotation(Method method) {
+        return Arrays.stream(method.getDeclaredAnnotations()).anyMatch(anno
+            -> anno.annotationType().getAnnotation(HttpMethod.class) != null);
+    }
+
+}

--- a/ozark/src/test/java/org/glassfish/ozark/uri/ApplicationUrisTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/uri/ApplicationUrisTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.glassfish.ozark.uri.UriBuilderTestControllers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <p>The test for {@link ApplicationUris}.</p>
+ *
+ * @author Florian Hirsch
+ */
+public class ApplicationUrisTest {
+
+    private ApplicationUris uris;
+
+    private static final String PATH = "/foo";
+
+    private static UriTemplate TEMPLATE = UriTemplate.fromTemplate(PATH).build();
+
+    @Before
+    public void onBefore() {
+        uris = new ApplicationUris();
+    }
+
+    @Test
+    public void shouldBuildWithMapParams() throws NoSuchMethodException {
+        uris.register(UriTemplate.fromTemplate("/a/{b}/{c}").queryParam("q").matrixParam("m").build(),
+            SomeController.class.getMethod("root"));
+        Map<String, Object> params = new HashMap<>();
+        params.put("b", "d");
+        params.put("c", "e");
+        params.put("m", 1);
+        params.put("q", 2);
+        assertThat(uris.get("SomeController#root", params).toString(), equalTo("/a/d/e;m=1?q=2"));
+    }
+
+    @Test
+    public void shouldRegisterByNameAndRef() throws NoSuchMethodException {
+        uris.register(TEMPLATE, UriRefController.class.getMethod("getRoot"));
+        assertThat(uris.get("uri-ref").toString(), equalTo(PATH));
+        assertThat(uris.get("UriRefController#getRoot").toString(), equalTo(PATH));
+        assertThat(uris.list().size(), is(2));
+    }
+
+    @Test
+    public void shouldAllowSameIdentifierForSamePath() throws NoSuchMethodException {
+        uris.register(TEMPLATE, UriRefController.class.getMethod("getRoot"));
+        uris.register(TEMPLATE, UriRefController.class.getMethod("postRoot"));
+        uris.get("uri-ref");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailForAmbiguousRefs() throws NoSuchMethodException {
+        uris.register(TEMPLATE, UriRefController.class.getMethod("getRoot"));
+        uris.register(UriTemplate.fromTemplate("/bar").build(),
+            AmbiguousController.class.getMethod("getAmbiguousRoot"));
+        uris.get("uri-ref");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shoulFailIfNoTemplateFound() throws NoSuchMethodException {
+        uris.register(TEMPLATE, SomeController.class.getMethod("root"));
+        uris.get("not#found");
+    }
+
+}

--- a/ozark/src/test/java/org/glassfish/ozark/uri/DefaultMvcUriBuilderTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/uri/DefaultMvcUriBuilderTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <p>The test for {@link DefaultMvcUriBuilder}.</p>
+ *
+ * @author Florian Hirsch
+ */
+public class DefaultMvcUriBuilderTest {
+
+    private static UriTemplate basePath = UriTemplate.fromTemplate("/base-path").build();
+
+    private static UriTemplate pathParams = UriTemplate.fromTemplate("/path-params/{p1}/{p2}/{p3}").build(); //
+
+    private static UriTemplate identicalPathParams = UriTemplate.fromTemplate("/path-params/{p1}/{p1}").build(); //
+
+    private static UriTemplate queryParams = UriTemplate.fromTemplate("/query-params") //
+        .queryParam("q1").queryParam("q2").queryParam("q3").build(); //
+
+    private static UriTemplate matrixParams = UriTemplate.fromTemplate("/matrix-params") //
+        .matrixParam("m1").matrixParam("m2").matrixParam("m3").build();
+
+    private static UriTemplate allParams = UriTemplate.fromTemplate("/params/{p1}/{p2}/{p3}") //
+        .matrixParam("m1").matrixParam("m2").matrixParam("m3") //
+        .queryParam("q1").queryParam("q2").queryParam("q3").build(); //
+
+    @Test
+    public void shouldBuildWithoutParams() {
+        assertThat(new DefaultMvcUriBuilder(basePath).build().toString(), equalTo("/base-path"));
+    }
+
+    @Test
+    public void shouldHandlePathParams() {
+        assertThat(new DefaultMvcUriBuilder(pathParams).param("p1", 1) //
+                .param("p2", "2").param("p3", 3).build().toString(), //
+            equalTo("/path-params/1/2/3")); //
+    }
+
+    @Test
+    public void shouldHandleQueryParams() {
+        assertThat(new DefaultMvcUriBuilder(queryParams) //
+            .param("q1", 7).param("q2", "8").param("q3", 9).build().toString(), //
+            equalTo("/query-params?q1=7&q2=8&q3=9"));
+    }
+
+    @Test
+    public void shouldHandleMatrixParams() {
+        assertThat(new DefaultMvcUriBuilder(matrixParams) //
+            .param("m1", 3).param("m2", "4").param("m3", 5).build().toString(), //
+            equalTo("/matrix-params;m1=3;m2=4;m3=5")); //
+    }
+
+    @Test
+    public void shouldHandleMixedParams() {
+        assertThat(new DefaultMvcUriBuilder(allParams).param("p1", 1).param("p2", "2") //
+            .param("p3", 3).param("m1", 4).param("q1", "7").build().toString(), //
+            equalTo("/params/1/2/3;m1=4?q1=7")); //
+    }
+
+    @Test
+    public void shouldHandleIdenticalPathParams() {
+        assertThat(new DefaultMvcUriBuilder(identicalPathParams) //
+                .param("p1", 1).build().toString(), equalTo("/path-params/1/1")); //
+    }
+
+    @Test
+    public void shouldHandleListOfQueryParams() {
+        // two param calls
+        assertThat(new DefaultMvcUriBuilder(queryParams) //
+            .param("q1", 9).param("q1", "10").build().toString(), //
+            equalTo("/query-params?q1=9&q1=10")); //
+        // varargs
+        assertThat(new DefaultMvcUriBuilder(queryParams) //
+            .param("q1", 9, "10").build().toString(), //
+            equalTo("/query-params?q1=9&q1=10")); //
+        // list
+        assertThat(new DefaultMvcUriBuilder(queryParams) //
+            .param("p3", 3).param("q1", Arrays.asList(9, "10")).build().toString(), //
+            equalTo("/query-params?q1=9&q1=10")); //
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailForMissingPathParameters() {
+        new DefaultMvcUriBuilder(allParams).param("p1", 1).build();
+    }
+
+}

--- a/ozark/src/test/java/org/glassfish/ozark/uri/UriBuilderTestControllers.java
+++ b/ozark/src/test/java/org/glassfish/ozark/uri/UriBuilderTestControllers.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import javax.mvc.annotation.Controller;
+import javax.mvc.annotation.UriRef;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.MatrixParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * Some Controllers for {@link javax.mvc.MvcUriBuilder related tests}
+ *
+ * @author Florian Hirsch
+ */
+class UriBuilderTestControllers {
+
+	@Controller
+	@Path("some")
+	static class SomeController extends SuperController {
+
+		@GET
+		public String root() {
+			return null;
+		}
+
+		@GET
+		@Path("path")
+		public String path() {
+			return null;
+		}
+
+		@Override
+		public String parent() {
+			return null;
+		}
+
+	}
+
+	static class SuperController {
+
+		@GET
+		@Path("parent")
+		public String parent() {
+			return null;
+		}
+
+	}
+
+	interface ControllerInterface {
+
+		@GET
+		@Path("show")
+		String show();
+
+	}
+
+	@Controller
+	@Path("implementation")
+	static class ControllerImplementation implements ControllerInterface {
+
+		@Override
+		public String show() {
+			return null;
+		}
+
+	}
+
+	@Controller
+	@Path("params")
+	static class ParamsController {
+
+		@GET
+		public String root() {
+			return null;
+		}
+
+		@GET
+		@Path("path/{p1}/{p2}")
+		public String pathParams(@PathParam("p1") String p1, @PathParam("p2") long p2) {
+			return null;
+		}
+
+		@GET
+		@Path("query")
+		public String queryParams(@QueryParam("q1") String q1, @QueryParam("q2") long q2) {
+			return null;
+		}
+
+		@GET
+		@Path("matrix")
+		public String matrixParams(@MatrixParam("m1") String m1, @MatrixParam("m2") long m2) {
+			return null;
+		}
+
+	}
+
+	@Controller
+	@Path("fields/{p1}/{p2}/{p3}")
+	static class FieldsController {
+
+		@PathParam("p1")
+		private String p1;
+
+		private String p2;
+
+		private String p3;
+
+		@QueryParam("q1")
+		private String q1;
+
+		private String q2;
+
+		private String q3;
+
+		@MatrixParam("m1")
+		private String m1;
+
+		private String m2;
+
+		private String m3;
+
+		@GET
+		public String root() {
+			return null;
+		}
+
+		public String getP1() {
+			return p1;
+		}
+
+		public void setP1(String p1) {
+			this.p1 = p1;
+		}
+
+		@PathParam("p2")
+		public String getP2() {
+			return p2;
+		}
+
+		public void setP2(String p2) {
+			this.p2 = p2;
+		}
+
+		public String getP3() {
+			return p3;
+		}
+
+		@PathParam("p3")
+		public void setP3(String p3) {
+			this.p3 = p3;
+		}
+
+		public String getQ1() {
+			return q1;
+		}
+
+		public void setQ1(String q1) {
+			this.q1 = q1;
+		}
+
+		@QueryParam("q2")
+		public String getQ2() {
+			return q2;
+		}
+
+		public void setQ2(String q2) {
+			this.q2 = q2;
+		}
+
+		public String getQ3() {
+			return q3;
+		}
+
+		@QueryParam("q3")
+		public void setQ3(String q3) {
+			this.q3 = q3;
+		}
+
+		public String getM1() {
+			return m1;
+		}
+
+		public void setM1(String m1) {
+			this.m1 = m1;
+		}
+
+		@MatrixParam("m2")
+		public String getM2() {
+			return m2;
+		}
+
+		public void setM2(String m2) {
+			this.m2 = m2;
+		}
+
+		public String getM3() {
+			return m3;
+		}
+
+		@MatrixParam("m3")
+		public void setM3(String m3) {
+			this.m3 = m3;
+		}
+
+	}
+
+	@Controller
+	@Path("bean")
+	static class BeanParamController {
+
+		@GET
+		@Path("{p}")
+		public String bean(@BeanParam BeanParams params) {
+			return null;
+		}
+
+	}
+
+	static class BeanParams {
+
+		@PathParam("p")
+		private String p;
+
+		@QueryParam("q")
+		private String q;
+
+		@MatrixParam("m")
+		private String m;
+
+	}
+
+	@Controller
+	@Path("ref")
+	static class UriRefController {
+
+		@GET
+		@UriRef("uri-ref")
+		public String getRoot() {
+			return null;
+		}
+
+		@POST
+		@UriRef("uri-ref")
+		public String postRoot() {
+			return null;
+		}
+
+	}
+
+	@Controller
+	@Path("ambiguous")
+	static class AmbiguousController {
+
+		@GET
+		@UriRef("uri-ref")
+		public String getAmbiguousRoot() {
+			return null;
+		}
+
+	}
+
+}

--- a/ozark/src/test/java/org/glassfish/ozark/uri/UriTemplateParserTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/uri/UriTemplateParserTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.uri;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.mvc.MvcContext;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.glassfish.ozark.uri.UriBuilderTestControllers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <p>The test for {@link UriTemplateParser}.</p>
+ *
+ * @author Florian Hirsch
+ */
+public class UriTemplateParserTest {
+
+    private static final String BASE_PATH = "/base-path";
+
+    private UriTemplateParser uriTemplateParser;
+
+    @Before
+    public void onBefore() {
+        uriTemplateParser = new UriTemplateParser();
+        MvcContext mvcContext = createMock(MvcContext.class);
+        expect(mvcContext.getBasePath()).andReturn(BASE_PATH).anyTimes();
+        replay(mvcContext);
+        uriTemplateParser.mvcContext = mvcContext;
+    }
+
+    @Test
+    public void shouldInitApplicationUris() {
+        HashSet<Class<?>> controllers = new HashSet<>(Arrays.asList(SomeController.class, ParamsController.class));
+        ApplicationUris uris = uriTemplateParser.init(controllers);
+        assertThat(uris.list().size(), is(7));
+    }
+
+    @Test
+    public void shouldParseMethods() throws NoSuchMethodException {
+        assertThat(uriTemplateParser.parseMethod(SomeController.class.getMethod("root"), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/some").build()));
+        assertThat(uriTemplateParser.parseMethod(SomeController.class.getMethod("path"), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/some/path").build()));
+    }
+
+    @Test
+    public void shouldParseFromInheritedMethods() throws NoSuchMethodException {
+        assertThat(uriTemplateParser.parseMethod(SomeController.class.getMethod("parent"), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/some/parent").build()));
+        assertThat(uriTemplateParser.parseMethod(ControllerImplementation.class.getMethod("show"), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/implementation/show").build()));
+    }
+
+    @Test
+    public void shouldParseMethodParams() throws NoSuchMethodException {
+        assertThat(uriTemplateParser.parseMethod(
+            ParamsController.class.getMethod("pathParams", String.class, long.class), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/params/path/{p1}/{p2}").build()));
+        assertThat(uriTemplateParser.parseMethod(
+            ParamsController.class.getMethod("queryParams", String.class, long.class), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/params/query").queryParam("q1").queryParam("q2").build()));
+        assertThat(uriTemplateParser.parseMethod(
+            ParamsController.class.getMethod("matrixParams", String.class, long.class), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/params/matrix").matrixParam("m1").matrixParam("m2").build()));
+    }
+
+    @Test
+    public void shouldParseFields() throws NoSuchMethodException {
+        assertThat(uriTemplateParser.parseMethod(FieldsController.class.getMethod("root"), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/fields/{p1}/{p2}/{p3}") //
+                .matrixParam("m1").matrixParam("m2").matrixParam("m3") //
+                .queryParam("q1").queryParam("q2").queryParam("q3").build())); //
+    }
+
+    @Test
+    public void shouldParseBeanParams() throws NoSuchMethodException {
+        assertThat(uriTemplateParser.parseMethod(
+            BeanParamController.class.getMethod("bean", BeanParams.class), BASE_PATH),
+            equalTo(UriTemplate.fromTemplate("/base-path/bean/{p}").matrixParam("m").queryParam("q").build()));
+    }
+
+}

--- a/ozark/src/test/java/org/glassfish/ozark/util/BeanUtilsTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/util/BeanUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.util;
+
+import org.junit.Test;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * The JUnit tests for the {@link BeanUtils} class.
+ *
+ * @author Florian Hirsch
+ */
+public class BeanUtilsTest {
+
+    @Test
+    public void shouldFindFieldsAndAccessors() {
+        List<AnnotatedElement> fieldsAndAccessors = BeanUtils.getFieldsAndAccessors(SomeBean.class);
+        assertThat(fieldsAndAccessors.size(), is(3));
+        fieldsAndAccessors.forEach(fieldsAndAccessor ->
+            assertThat(fieldsAndAccessor.toString().toLowerCase(), containsString("foo"))
+        );
+    }
+
+    private static class SomeBean {
+        private String foo;
+        public String getFoo() {
+            return foo;
+        }
+        public void setFoo(String foo) {
+            this.foo = foo;
+        }
+        public String bar() {
+            return null;
+        }
+    }
+
+}

--- a/ozark/src/test/java/org/glassfish/ozark/util/CdiUtilsTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/util/CdiUtilsTest.java
@@ -28,25 +28,25 @@ import static org.junit.Assert.assertNull;
 
 /**
  * The JUnit tests for the CdiUtils class.
- * 
+ *
  * @author Manfred Riem (manfred.riem at oracle.com)
  */
 public class CdiUtilsTest {
-    
+
     /**
      * Test newBean method.
-     * 
+     *
      * @throws Exception when a serious error occurs.
      */
     @Test
     public void testNewBean() throws Exception {
         CdiUtils utils = new CdiUtils();
-        
+
         Field bmField = utils.getClass().getDeclaredField("beanManager");
         bmField.setAccessible(true);
         BeanManager bm = EasyMock.createMock(BeanManager.class);
         bmField.set(utils, bm);
-        
+
         expect(bm.getBeans(CdiUtilsTest.class)).andReturn(null);
         expect(bm.resolve(null)).andReturn(null);
         expect(bm.createCreationalContext(null)).andReturn(null);
@@ -55,4 +55,5 @@ public class CdiUtilsTest {
         assertNull(utils.newBean(CdiUtilsTest.class));
         verify(bm);
     }
+
 }

--- a/ozark/src/test/java/org/glassfish/ozark/util/ControllerUtilsTest.java
+++ b/ozark/src/test/java/org/glassfish/ozark/util/ControllerUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.util;
+
+import org.junit.Test;
+
+import javax.mvc.annotation.Controller;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * The JUnit tests for the {@link ControllerUtils} class.
+ *
+ * @author Florian Hirsch
+ */
+public class ControllerUtilsTest {
+
+    @Test
+    public void shouldIdentifyControllerClasses() {
+        assertThat(ControllerUtils.isController(ClassController.class), is(true));
+        assertThat(ControllerUtils.isController(MethodController.class), is(true));
+        assertThat(ControllerUtils.isController(NoController.class), is(false));
+    }
+
+    @Test
+    public void shouldIdentifyControllerMethods() throws NoSuchMethodException {
+        assertThat(ControllerUtils.isControllerMethod(ClassController.class.getMethod("foo")), is(false));
+        assertThat(ControllerUtils.isControllerMethod(ClassController.class.getMethod("bar")), is(true));
+        assertThat(ControllerUtils.isControllerMethod(MethodController.class.getMethod("foo")), is(false));
+        assertThat(ControllerUtils.isControllerMethod(MethodController.class.getMethod("bar")), is(true));
+        assertThat(ControllerUtils.isControllerMethod(NoController.class.getMethod("foo")), is(false));
+        assertThat(ControllerUtils.isControllerMethod(NoController.class.getMethod("bar")), is(false));
+    }
+
+    @Test
+    public void shouldIdentifyRequestMethods() throws NoSuchMethodException {
+        assertThat(ControllerUtils.isRequestMethod(NoController.class.getMethod("foo")), is(false));
+        assertThat(ControllerUtils.isRequestMethod(NoController.class.getMethod("bar")), is(true));
+        assertThat(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("foo")), is(false));
+        assertThat(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("bar")), is(true));
+        assertThat(ControllerUtils.isRequestMethod(ControllerImpl.class.getMethod("foo")), is(true));
+        // if a subclass or implementation method has any MVC or JAX-RS annotations
+        // then all of the annotations on the superclass or interface method are ignored
+        assertThat(ControllerUtils.isRequestMethod(InheritedController.class.getMethod("baz")), is(false));
+        assertThat(ControllerUtils.isRequestMethod(ControllerImpl.class.getMethod("baz")), is(false));
+    }
+
+    @Test
+    public void shouldIdentifyDeclaredRequestMethodAnnotations() throws NoSuchMethodException {
+        assertThat(ControllerUtils.hasDeclaredRequestMethodAnnotation(
+            MethodController.class.getMethod("foo")), is(false));
+        assertThat(ControllerUtils.hasDeclaredRequestMethodAnnotation(
+            MethodController.class.getMethod("bar")), is(true));
+    }
+
+    @Controller
+    private static class ClassController {
+        public void foo() {}
+        @GET public void bar() {}
+        @GET public void baz() {}
+    }
+
+    private static class MethodController {
+        @Controller public void foo() {}
+        @Controller @GET public void bar() {}
+    }
+
+    private static class NoController {
+        public void foo() {}
+        @GET public void bar() {}
+    }
+
+    private static class InheritedController extends ClassController {
+        public void foo() {}
+        public void bar() {}
+        @Path("baz") public void baz() {}
+    }
+
+    private interface ControllerInterface {
+        @GET void foo();
+        @GET void baz();
+    }
+
+    private static class ControllerImpl implements ControllerInterface {
+        public void foo() {}
+        @Path("baz") public void baz() {}
+    }
+
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -83,6 +83,7 @@
         <module>velocity</module>
         <module>view-annotation</module>
         <module>pebble</module>
+        <module>uri-builder</module>
     </modules>
     <profiles>
         <profile>

--- a/test/uri-builder/pom.xml
+++ b/test/uri-builder/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mvc-spec.ozark.test</groupId>
+        <artifactId>ozark-parent-test</artifactId>
+        <version>1.0.0-m03-SNAPSHOT</version>
+    </parent>
+    <artifactId>uri-builder</artifactId>
+    <packaging>war</packaging>
+    <name>Ozark MvcUriBuilder Test</name>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+    </build>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+</project>

--- a/test/uri-builder/src/main/java/org/glassfish/ozark/test/uribuilder/ParameterController.java
+++ b/test/uri-builder/src/main/java/org/glassfish/ozark/test/uribuilder/ParameterController.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.test.uribuilder;
+
+import javax.mvc.annotation.Controller;
+import javax.mvc.annotation.UriRef;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.MatrixParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * @author Florian Hirsch
+ */
+@Controller
+@Path("parameters")
+public class ParameterController {
+
+    @GET
+    @Path("path/{p1}/{p2}")
+    @UriRef("path-params")
+    public String pathParams(@PathParam("p1") String p1, @PathParam("p2") long p2) {
+        return "uri-builder.jsp";
+    }
+
+    @GET
+    @Path("query")
+    @UriRef("query-params")
+    public String queryParams(@QueryParam("q1") String q1, @QueryParam("q2") long q2) {
+        return "uri-builder.jsp";
+    }
+
+    @GET
+    @Path("matrix")
+    @UriRef("matrix-params")
+    public String matrixParams(@MatrixParam("m1") String m1, @MatrixParam("m2") long m2) {
+        return "uri-builder.jsp";
+    }
+
+    @GET
+    @Path("bean/{p}")
+    @UriRef("bean-params")
+    public String beanParams(@BeanParam BeanParams params) {
+        return "uri-builder.jsp";
+    }
+
+    static class BeanParams {
+
+        @PathParam("p")
+        private String p;
+
+        @QueryParam("q")
+        private String q;
+
+        @MatrixParam("m")
+        private long m;
+
+    }
+
+}

--- a/test/uri-builder/src/main/java/org/glassfish/ozark/test/uribuilder/UriBuilderApplication.java
+++ b/test/uri-builder/src/main/java/org/glassfish/ozark/test/uribuilder/UriBuilderApplication.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.test.uribuilder;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Florian Hirsch
+ */
+@ApplicationPath("resources")
+public class UriBuilderApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> classes = new HashSet<>();
+        classes.add(UriBuilderController.class);
+        classes.add(ParameterController.class);
+        return classes;
+    }
+
+}

--- a/test/uri-builder/src/main/java/org/glassfish/ozark/test/uribuilder/UriBuilderController.java
+++ b/test/uri-builder/src/main/java/org/glassfish/ozark/test/uribuilder/UriBuilderController.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.test.uribuilder;
+
+import javax.mvc.annotation.Controller;
+import javax.mvc.annotation.UriRef;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * @author Florian Hirsch
+ */
+@Controller
+@Path("uri-builder")
+public class UriBuilderController {
+
+    @GET
+    @UriRef("some-ref")
+    public String get() {
+        return "uri-builder.jsp";
+    }
+
+}

--- a/test/uri-builder/src/main/webapp/WEB-INF/beans.xml
+++ b/test/uri-builder/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/test/uri-builder/src/main/webapp/WEB-INF/views/uri-builder.jsp
+++ b/test/uri-builder/src/main/webapp/WEB-INF/views/uri-builder.jsp
@@ -1,0 +1,167 @@
+<%@ page contentType="text/html;charset=utf-8" language="java" %>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>MvcUriBuilder examples</title>
+    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+</head>
+<body>
+<div class="container">
+
+    <h1>MvcUriBuilder</h1>
+
+    <p>
+        Hardcoding URIs in a template can be awkward.
+        The MVC specification provides the
+        <a href="https://github.com/mvc-spec/mvc-spec/blob/master/api/src/main/java/javax/mvc/MvcUriBuilder.java">MvcUriBuilder</a>
+        to generate URIs from <code>@Path</code>,
+        <code>@PathParam</code>, <code>@QueryParam</code> and <code>@MatrixParam</code> annotations.
+        It can be used from a template but also from Java code.
+    </p>
+
+    <h2>Simple URLs without parameters</h2>
+
+    <p>Given following controller:</p>
+
+    <pre><code>@Controller
+@Path("uri-builder")
+public class UriBuilderController {
+
+    @GET
+    @UriRef("some-ref")
+    public String get() {
+        return "uri-builder.jsp";
+    }
+
+}</code></pre>
+
+    <p>A controller method to build the URI for can be referenced in two ways.</p>
+
+    <p>
+        First you can use the <a href="https://github.com/mvc-spec/mvc-spec/blob/master/api/src/main/java/javax/mvc/annotation/UriRef.java">UriRef</a>
+        annotation to define a symbolic name for a controller method.
+        To do so just place the annotation on the controller method and specify the name in the value attribute as shown in the controller above.
+    </p>
+
+    <p>Now you can generate the corresponding URI using a simple EL expression like this:</p>
+
+    <pre>
+        \${mvc.uri('some-ref')}<br />
+        &lt!-- <span id="uri-ref">${mvc.uri('some-ref')}</span> --&gt
+    </pre>
+
+    <p class="note">
+        <strong>Note:</strong> You should use <code>UriRef</code> only on one method if you have the same URI-template
+        but multiple controller methods for different HTTP verbs.
+    </p>
+
+    <p>
+        But you don't have to use <code>UriRef</code> to use the <code>MvcUriBuilder</code>.
+        You can also reference a controller method with the simple class name of your
+        controller and the method name seperated by a '#':
+    </p>
+
+    <pre>
+        \${mvc.uri('UriBuilderController#get')}<br />
+        &lt!-- <span id="method-ref">${mvc.uri('UriBuilderController#get')}</span> --&gt;
+    </pre>
+
+    <p>Please note that this only works if the simple class name is not ambiguous.</p>
+
+    <h2>Specifying parameters</h2>
+
+    <p>
+        The first section described how to link to controller methods without any parameters.
+        But in real world application most controller methods will use
+        parameters which you need to specify when creating the URI.
+    </p>
+
+    <p>See the following controller as an example:</p>
+
+    <pre><code>@Controller
+@Path("parameters")
+public class ParameterController {
+
+    @GET
+    @Path("path/{p1}/{p2}")
+    @UriRef("path-params")
+    public String pathParams(@PathParam("p1") String p1, @PathParam("p2") long p2) {
+        return "uri-builder.jsp";
+    }
+
+    @GET
+    @Path("query")
+    @UriRef("query-params")
+    public String queryParams(@QueryParam("q1") String q1, @QueryParam("q2") long q2) {
+        return "uri-builder.jsp";
+    }
+
+    @GET
+    @Path("matrix")
+    @UriRef("matrix-params")
+    public String matrixParams(@MatrixParam("m1") String m1, @MatrixParam("m2") long m2) {
+        return "uri-builder.jsp";
+    }
+
+    @GET
+    @Path("bean/{p}")
+    @UriRef("bean-params")
+    public String beanParams(@BeanParam BeanParams params) {
+        return "uri-builder.jsp";
+    }
+
+    static class BeanParams {
+
+        @PathParam("p")
+        private String p;
+
+        @QueryParam("q")
+        private String q;
+
+        @MatrixParam("m")
+        private long m;
+
+    }
+
+}</code></pre>
+
+    <p>
+        To set path parameters when building an URI, you have to provide a map containing the values for each parameter.
+        Please note that you will have to set all path parameters because path parameters are required for the URI:
+    </p>
+
+    <pre>
+        \${mvc.uri('path-params', {'p1': 'baz', 'p2': 4711})}<br />
+        &lt!-- <span id="path-params">${mvc.uri('path-params', {'p1': 'baz', 'p2': 4711})}</span> --&gt;
+    </pre>
+
+    <p>You can also set query parameter values using a map:</p>
+
+    <pre>
+        \${mvc.uri('query-params', {'q1': 'foo', 'q2': 42})}<br />
+        &lt!-- <span id="query-params">${mvc.uri('query-params', {'q1': 'foo', 'q2': 42})}</span> --&gt;
+    </pre>
+
+    <p>And also matrix parameters:</p>
+
+    <pre>
+        \${mvc.uri('matrix-params', {'m1': 'foo', 'm2': 42})}<br />
+        &lt!-- <span id="matrix-params">${mvc.uri('matrix-params', {'m1': 'foo', 'm2': 42})}</span> --&gt;
+    </pre>
+
+    <p>
+        The type of the parameter is automatically infered from the corresponding annotations on your controller.
+        This means you can just specify the values by name and you don't have to care about the type of the parameter.
+        This also works with <code>@BeanParam</code> parameters.
+    </p>
+
+    <pre>
+        \${mvc.uri('bean-params', {'p': 'foo', 'm': 42, 'q': 'bar'})}<br />
+        &lt!-- <span id="bean-params">${mvc.uri('bean-params', {'p': 'foo', 'm': 42, 'q': 'bar'})}</span> --&gt;
+    </pre>
+
+</div>
+
+</body>
+</html>

--- a/test/uri-builder/src/main/webapp/index.html
+++ b/test/uri-builder/src/main/webapp/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>MvcUriBuilder test</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" type="text/css" href="ozark.css">
+</head>
+<body>
+<h1>MvcUriBuilder test</h1>
+<ul>
+    <li><a href="resources/uri-builder">resources/uri-builder</a>
+</ul>
+<br/>
+<a class="source" href="https://github.com/mvc-spec/ozark/blob/master/test/thymeleaf/src/main/java/org/glassfish/ozark/test/uribuilder/UriBuilderController.java">Source Code</a>
+</body>
+</html>

--- a/test/uri-builder/src/main/webapp/ozark.css
+++ b/test/uri-builder/src/main/webapp/ozark.css
@@ -1,0 +1,78 @@
+h1 {
+    color: steelblue;
+    font-size: 30px;
+}
+
+h2 {
+    color: steelblue;
+    font-size: 24px;
+    margin-top: 20px;
+}
+
+input {
+    width: 200px;
+    display: block;
+    border: 1px solid #999;
+    height: 25px;
+    margin-bottom: 5px;
+}
+
+input[type=submit] {
+    width: 150px;
+    padding: 5px 5px;
+    background: steelblue;
+    color: white;
+    border: 0 none;
+    cursor: pointer;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    margin-top: 15px;
+}
+
+.source {
+    width: 150px;
+    padding: 8px 8px 8px 8px;
+    background: steelblue;
+    color: white;
+    border: 0 none;
+    cursor: pointer;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    margin-top: 15px;
+}
+
+.table {
+    width: 70%;
+    border-collapse: collapse;
+    color: white;
+}
+
+.table td {
+    padding: 7px;
+}
+
+.table th {
+    background: steelblue;
+    color: white;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    text-align: left;
+    padding-left: 5px;
+    font-size: 125%;
+}
+
+.table tr {
+    background: steelblue;
+}
+
+.table tr:nth-child(odd) {
+    background: steelblue;
+}
+
+.table tr:nth-child(even) {
+    background: lightsteelblue;
+}
+
+.table a {
+    color: white;
+}

--- a/test/uri-builder/src/test/java/org/glassfish/ozark/test/uribuilder/MvcUriBuilderIT.java
+++ b/test/uri-builder/src/test/java/org/glassfish/ozark/test/uribuilder/MvcUriBuilderIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.glassfish.ozark.test.uribuilder;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Florian Hirsch
+ */
+public class MvcUriBuilderIT {
+
+    private String webUrl;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.closeAllWindows();
+    }
+
+    @Test
+    public void test() throws Exception {
+        HtmlPage page = webClient.getPage(webUrl + "resources/uri-builder");
+        assertThat(page.getElementById("uri-ref").asText(),
+            equalTo("/uri-builder/resources/uri-builder"));
+        assertThat(page.getElementById("method-ref").asText(),
+            equalTo("/uri-builder/resources/uri-builder"));
+        assertThat(page.getElementById("path-params").asText(),
+            equalTo("/uri-builder/resources/parameters/path/baz/4711"));
+        assertThat(page.getElementById("query-params").asText(),
+            equalTo("/uri-builder/resources/parameters/query?q1=foo&q2=42"));
+        assertThat(page.getElementById("matrix-params").asText(),
+            equalTo("/uri-builder/resources/parameters/matrix;m1=foo;m2=42"));
+        assertThat(page.getElementById("bean-params").asText(),
+            equalTo("/uri-builder/resources/parameters/bean/foo;m=42?q=bar"));
+    }
+
+}


### PR DESCRIPTION
Implementation of [MvcUriBuilder][1]. 
Following method of `MvcContext` is still not implemented:

```URI uri(String identifier, List<Object> params);```

Reason is that method overloading is not supported by EL. This is the reason why one of the integration tests is failing. 

I started a [discussion in the mailing list][2] if we should drop this method.

 [1]: https://github.com/mvc-spec/mvc-spec/blob/master/api/src/main/java/javax/mvc/MvcUriBuilder.java
 [2]: https://groups.google.com/forum/#!topic/jsr371-users/VU2BitCkJsQ