### PR TITLE
Remove overloaded method MvcContext#uri(identifier, params)

### DIFF
--- a/ozark/src/main/java/org/glassfish/ozark/MvcContextImpl.java
+++ b/ozark/src/main/java/org/glassfish/ozark/MvcContextImpl.java
@@ -129,11 +129,6 @@ public class MvcContextImpl implements MvcContext {
     }
 
     @Override
-    public URI uri(String s, List<Object> list) {
-        throw new UnsupportedOperationException("Not implemented yet!");
-    }
-
-    @Override
     public URI uri(String s, Map<String, Object> map) {
         throw new UnsupportedOperationException("Not implemented yet!");
     }


### PR DESCRIPTION
Method overloading is not supported by EL. See [this discussion](https://groups.google.com/forum/#!topic/jsr371-users/VU2BitCkJsQ) and [mvc-spec PR #98](https://github.com/mvc-spec/mvc-spec/pull/98).