### PR TITLE
Update Velocity Version.

### DIFF
--- a/ext/velocity/pom.xml
+++ b/ext/velocity/pom.xml
@@ -30,14 +30,20 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity-engine-core</artifactId>
-            <version>2.0</version>
+            <artifactId>velocity</artifactId>
+            <version>1.7</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-tools</artifactId>
             <version>2.0</version>
+          <exclusions>
+                <exclusion>
+                    <groupId>org.apache.velocity</groupId>
+                    <artifactId>velocity</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/ext/velocity/pom.xml
+++ b/ext/velocity/pom.xml
@@ -30,14 +30,14 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>1.7</version>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>2.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>velocity-tools</groupId>
-            <artifactId>velocity-tools-view</artifactId>
-            <version>2.0-beta1</version>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity-tools</artifactId>
+            <version>2.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/DefaultVelocityEngineProducer.java
+++ b/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/DefaultVelocityEngineProducer.java
@@ -37,7 +37,7 @@ public class DefaultVelocityEngineProducer {
     public VelocityEngine getVelocityEngine() {
         VelocityEngine velocityEngine = new VelocityEngine();
         velocityEngine.setProperty("resource.loader", "webapp");
-        velocityEngine.setProperty("webapp.resource.loader.class", "org.apache.velocity.tools.view.servlet.WebappLoader");
+        velocityEngine.setProperty("webapp.resource.loader.class", "org.apache.velocity.tools.view.WebappResourceLoader");
         velocityEngine.setApplicationAttribute("javax.servlet.ServletContext", servletContext);
         velocityEngine.init();
         return velocityEngine;


### PR DESCRIPTION
fix #136 

According to the log, this statement is deprecated:` org.apache.velocity.tools.view.servlet.WebappLoader`. That was the only change.