### PR TITLE
Controller detection doesn't work on RESTEasy

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,6 +35,10 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>

--- a/core/src/main/java/org/mvcspec/ozark/bootstrap/OzarkCoreFeature.java
+++ b/core/src/main/java/org/mvcspec/ozark/bootstrap/OzarkCoreFeature.java
@@ -15,8 +15,10 @@
  */
 package org.mvcspec.ozark.bootstrap;
 
+import javax.servlet.ServletContext;
 import javax.ws.rs.ConstrainedTo;
 import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
@@ -31,9 +33,12 @@ import javax.ws.rs.ext.Provider;
 @ConstrainedTo(RuntimeType.SERVER)
 public class OzarkCoreFeature implements Feature {
 
+    @Context
+    private ServletContext servletContext;
+
     @Override
     public boolean configure(FeatureContext context) {
-        OzarkInitializer.initialize(context);
+        OzarkInitializer.initialize(context, servletContext);
         return true;
     }
 

--- a/core/src/main/java/org/mvcspec/ozark/servlet/OzarkContainerInitializer.java
+++ b/core/src/main/java/org/mvcspec/ozark/servlet/OzarkContainerInitializer.java
@@ -21,8 +21,13 @@ import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 import javax.ws.rs.ApplicationPath;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.mvc.annotation.Controller;
+import javax.ws.rs.Path;
 
 import static org.mvcspec.ozark.util.AnnotationUtils.getAnnotation;
+import static org.mvcspec.ozark.util.AnnotationUtils.hasAnnotationOnClassOrMethod;
 
 /**
  * Initializes the Mvc class with the application and context path. Note that the
@@ -30,19 +35,37 @@ import static org.mvcspec.ozark.util.AnnotationUtils.getAnnotation;
  * is annotated by {@link javax.ws.rs.ApplicationPath}.
  *
  * @author Santiago Pericas-Geertsen
+ * @author Dmytro Maidaniuk
  */
-@HandlesTypes({ ApplicationPath.class })
+@HandlesTypes({ ApplicationPath.class, Path.class })
 public class OzarkContainerInitializer implements ServletContainerInitializer {
 
     public static final String APP_PATH_CONTEXT_KEY = OzarkContainerInitializer.class.getName() + ".APP_PATH";
+    public static final String OZARK_ENABLE_FEATURES_KEY = "ozark.enableFeatures";
+    private static final Logger LOG = Logger.getLogger(OzarkContainerInitializer.class.getName());
 
     @Override
     public void onStartup(Set<Class<?>> classes, ServletContext servletContext) throws ServletException {
+        servletContext.setAttribute(OZARK_ENABLE_FEATURES_KEY, false);
         if (classes != null && !classes.isEmpty()) {
-            final Class<?> appClass = classes.iterator().next();    // must be a singleton
-            final ApplicationPath ap = getAnnotation(appClass, ApplicationPath.class);
-            if (ap != null) {
-                servletContext.setAttribute(APP_PATH_CONTEXT_KEY, ap.value());
+            LOG.log(Level.INFO, "Ozark version {0} started", getClass().getPackage().getImplementationVersion());
+            for (Class<?> clazz : classes) {
+                final ApplicationPath ap = getAnnotation(clazz, ApplicationPath.class);
+                if (ap != null) {
+                    if (servletContext.getAttribute(APP_PATH_CONTEXT_KEY) != null) {
+                        // must be a singleton
+                        throw new IllegalStateException("More than one JAX-RS ApplicationPath detected!");
+                    }
+                    servletContext.setAttribute(APP_PATH_CONTEXT_KEY, ap.value());
+                }
+                if (hasAnnotationOnClassOrMethod(clazz, Path.class)
+                        && hasAnnotationOnClassOrMethod(clazz, Controller.class)) {
+                    servletContext.setAttribute(OZARK_ENABLE_FEATURES_KEY, true);
+                }
+                if (servletContext.getAttribute(APP_PATH_CONTEXT_KEY) != null
+                        && (Boolean) servletContext.getAttribute(OZARK_ENABLE_FEATURES_KEY) == true) {
+                    break;  // no need to loop further
+                }
             }
         }
     }

--- a/core/src/main/java/org/mvcspec/ozark/util/AnnotationUtils.java
+++ b/core/src/main/java/org/mvcspec/ozark/util/AnnotationUtils.java
@@ -148,6 +148,20 @@ public final class AnnotationUtils {
     }
 
     /**
+     * Determines if an annotation is present on a class or its methods by calling {@link #getAnnotation(Class, Class)}
+     * and {@link #getAnnotation(java.lang.reflect.Method, Class)} iteratively.
+     *
+     * @param <T> the type.
+     * @param clazz class to search annotation.
+     * @param annotationType type of annotation to search for.
+     * @return outcome of test.
+     */
+    public static <T extends Annotation> boolean hasAnnotationOnClassOrMethod(Class<?> clazz, Class<T> annotationType) {
+        return hasAnnotation(clazz, annotationType)
+                || Arrays.stream(clazz.getMethods()).anyMatch(m -> hasAnnotation(m, annotationType));
+    }
+
+    /**
      * Determines if a method has one or more MVC or JAX-RS annotations on it.
      *
      * @param method method to check for MVC or JAX-RS annotations.

--- a/jersey/src/main/java/org/mvcspec/ozark/jersey/bootstrap/OzarkJerseyFeature.java
+++ b/jersey/src/main/java/org/mvcspec/ozark/jersey/bootstrap/OzarkJerseyFeature.java
@@ -20,8 +20,10 @@ import org.glassfish.jersey.internal.spi.ForcedAutoDiscoverable;
 import org.mvcspec.ozark.bootstrap.OzarkInitializer;
 
 import javax.annotation.Priority;
+import javax.servlet.ServletContext;
 import javax.ws.rs.ConstrainedTo;
 import javax.ws.rs.RuntimeType;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.FeatureContext;
 
 /**
@@ -35,9 +37,12 @@ import javax.ws.rs.core.FeatureContext;
 @Priority(AutoDiscoverable.DEFAULT_PRIORITY)
 public class OzarkJerseyFeature implements ForcedAutoDiscoverable {
 
+    @Context
+    private ServletContext servletContext;
+
     @Override
     public void configure(FeatureContext context) {
-        OzarkInitializer.initialize(context);
+        OzarkInitializer.initialize(context, servletContext);
     }
 
 }


### PR DESCRIPTION
In this PR fixed problem with `OzarkFeature` when it not works properly in RESTEasy case. Issue was that RESTEasy return in `config` object only classes from sub-packages `org.jboss.resteasy`. It means that implementation provide only own classes there. I found proper way how to deal with this using `ServletContext`.
Additionally extended Manifest to provide implementation version information.