### PR TITLE
Enabled asciidoc tests for Glassfish 5.0 #134

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GLASSFISH_URL="http://download.oracle.com/glassfish/5.0/release/glassfish-5.0-web.zip"
+GLASSFISH_URL="http://download.oracle.com/glassfish/5.0.1/nightly/latest-web.zip"
 WILDFLY_URL="http://download.jboss.org/wildfly/11.0.0.CR1/wildfly-11.0.0.CR1.tar.gz"
 
 if [ "${1}" == "glassfish-bundled" ]; then

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -54,8 +54,7 @@
     <modules>
         <module>annotations</module>
         <module>application-path</module>
-        <!-- Doesn't work on Glassfish 5.0 b25 -->
-        <!--<module>asciidoc</module>-->
+        <module>asciidoc</module>
         <module>book-cdi</module>
         <module>book-models</module>
         <module>conversation</module>


### PR DESCRIPTION
Switched to latest version of glassfish 5.0.1 for verifying a bug-fix.
http://download.oracle.com/glassfish/5.0.1/nightly/latest-web.zip