### PR TITLE
Removed Servlet API dependency from MVC API

### DIFF
--- a/core/src/main/java/org/mvcspec/ozark/core/ViewableWriter.java
+++ b/core/src/main/java/org/mvcspec/ozark/core/ViewableWriter.java
@@ -207,7 +207,7 @@ public class ViewableWriter implements MessageBodyWriter<Viewable> {
 
             // Process view using selected engine
             engine.processView(new ViewEngineContextImpl(viewable.getView(), models, request, responseWrapper,
-                    uriInfo, resourceInfo, config));
+                    headers, responseStream, mediaType, uriInfo, resourceInfo, config));
 
             // Fire AfterProcessView event
             if (OzarkCdiExtension.isEventObserved(AfterProcessViewEvent.class)) {

--- a/core/src/main/java/org/mvcspec/ozark/engine/ServletViewEngine.java
+++ b/core/src/main/java/org/mvcspec/ozark/engine/ServletViewEngine.java
@@ -61,8 +61,8 @@ public abstract class ServletViewEngine extends ViewEngineBase {
     protected void forwardRequest(ViewEngineContext context, String... extensions)
             throws ServletException, IOException {
         RequestDispatcher rd = null;
-        HttpServletRequest request = context.getRequest();
-        final HttpServletResponse response = context.getResponse();
+        HttpServletRequest request = context.getRequest(HttpServletRequest.class);
+        final HttpServletResponse response = context.getResponse(HttpServletResponse.class);
 
         // Set attributes in request before forward
         final Models models = context.getModels();
@@ -77,7 +77,7 @@ public abstract class ServletViewEngine extends ViewEngineBase {
                 rd = servletContext.getNamedDispatcher(e.getKey());     // by servlet name
 
                 // Need new request with updated URI and extension matching semantics
-                request = new HttpServletRequestWrapper(context.getRequest()) {
+                request = new HttpServletRequestWrapper(context.getRequest(HttpServletRequest.class)) {
                     @Override
                     public String getRequestURI() {
                         return resolveView(context);

--- a/core/src/main/java/org/mvcspec/ozark/engine/ViewEngineBase.java
+++ b/core/src/main/java/org/mvcspec/ozark/engine/ViewEngineBase.java
@@ -20,6 +20,9 @@ import org.mvcspec.ozark.util.PropertyUtils;
 
 import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.nio.charset.Charset;
 
 /**
  * Base class for view engines that factors out all common logic.
@@ -44,4 +47,30 @@ public abstract class ViewEngineBase implements ViewEngine {
         }
         return view;
     }
+
+    /**
+     * This methods reads the 'charset' parameter from the media type and falls back to 'UTF-8'
+     * if the parameter is missing. It then adds a corresponding 'Content-Type' with the correct
+     * encoding to the response headers. Finally it returns the effective character set so that
+     * the view engine implementation can use it write the data correctly to the output stream.
+     *
+     * @param context The context
+     * @return the effective charset
+     */
+    protected Charset resolveCharsetAndSetContentType(ViewEngineContext context) {
+
+        String charset = context.getMediaType().getParameters().get("charset");
+        if (charset == null) {
+            charset = "UTF-8";
+        }
+
+        MediaType mediaType = context.getMediaType().withCharset(charset);
+
+        context.getResponseHeaders().putSingle(HttpHeaders.CONTENT_TYPE, mediaType.toString());
+
+        return Charset.forName(charset);
+
+    }
+
+
 }

--- a/core/src/main/java/org/mvcspec/ozark/engine/ViewEngineContextImpl.java
+++ b/core/src/main/java/org/mvcspec/ozark/engine/ViewEngineContextImpl.java
@@ -17,11 +17,12 @@ package org.mvcspec.ozark.engine;
 
 import javax.mvc.Models;
 import javax.mvc.engine.ViewEngineContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Configuration;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
+import java.io.OutputStream;
 
 /**
  * Implementation of {@link javax.mvc.engine.ViewEngineContext}. Provides all the information
@@ -35,9 +36,15 @@ public class ViewEngineContextImpl implements ViewEngineContext {
 
     private final Models models;
 
-    private final HttpServletRequest request;
+    private final Object request;
 
-    private final HttpServletResponse response;
+    private final Object response;
+
+    private final MultivaluedMap<String, Object> responseHeaders;
+
+    private final OutputStream outputStream;
+
+    private final MediaType mediaType;
 
     private final UriInfo uriInfo;
 
@@ -52,16 +59,24 @@ public class ViewEngineContextImpl implements ViewEngineContext {
      * @param models Instance of models.
      * @param request HTTP servlet request.
      * @param response HTTP servlet response.
+     * @param responseHeaders The response responseHeaders
+     * @param outputStream The response stream
+     * @param mediaType The media type
      * @param uriInfo URI info about the request.
      * @param resourceInfo Resource matched info.
      * @param configuration the configuration.
      */
-    public ViewEngineContextImpl(String view, Models models, HttpServletRequest request, HttpServletResponse response,
-                                 UriInfo uriInfo, ResourceInfo resourceInfo, Configuration configuration) {
+    public ViewEngineContextImpl(String view, Models models, Object request, Object response,
+                                 MultivaluedMap<String, Object> responseHeaders, OutputStream outputStream,
+                                 MediaType mediaType, UriInfo uriInfo, ResourceInfo resourceInfo,
+                                 Configuration configuration) {
         this.view = view;
         this.models = models;
         this.request = request;
         this.response = response;
+        this.responseHeaders = responseHeaders;
+        this.outputStream = outputStream;
+        this.mediaType = mediaType;
         this.uriInfo = uriInfo;
         this.resourceInfo = resourceInfo;
         this.configuration = configuration;
@@ -78,13 +93,28 @@ public class ViewEngineContextImpl implements ViewEngineContext {
     }
 
     @Override
-    public HttpServletRequest getRequest() {
-        return request;
+    public <T> T getRequest(Class<T> type) {
+        return type.cast(request);
     }
 
     @Override
-    public HttpServletResponse getResponse() {
-        return response;
+    public <T> T getResponse(Class<T> type) {
+        return type.cast(response);
+    }
+
+    @Override
+    public MultivaluedMap<String, Object> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return outputStream;
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return mediaType;
     }
 
     @Override

--- a/core/src/test/java/org/mvcspec/ozark/engine/ViewEngineContextImplTest.java
+++ b/core/src/test/java/org/mvcspec/ozark/engine/ViewEngineContextImplTest.java
@@ -39,7 +39,7 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetView() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl("view", null, null, null, null, null, null);
+        ViewEngineContextImpl context = new ViewEngineContextImpl("view", null, null, null, null, null, null, null, null, null);
         assertEquals("view", context.getView());
     }
 
@@ -48,9 +48,9 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetModels() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, null, null);
         assertNull(context.getModels());
-        context = new ViewEngineContextImpl(null, new ModelsImpl(), null, null, null, null, null);
+        context = new ViewEngineContextImpl(null, new ModelsImpl(), null, null, null, null, null, null, null, null);
         assertNotNull(context.getModels());
     }
 
@@ -59,12 +59,12 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetRequest() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
-        assertNull(context.getRequest());
+        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, null, null);
+        assertNull(context.getRequest(Object.class));
         HttpServletRequest request = EasyMock.createMock(HttpServletRequest.class);
         replay(request);
-        context = new ViewEngineContextImpl(null, null, request, null, null, null, null);
-        assertNotNull(context.getRequest());
+        context = new ViewEngineContextImpl(null, null, request, null, null, null, null, null, null, null);
+        assertNotNull(context.getRequest(Object.class));
         verify(request);
     }
 
@@ -73,12 +73,12 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetResponse() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
-        assertNull(context.getResponse());
+        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, null, null);
+        assertNull(context.getResponse(Object.class));
         HttpServletResponse response = EasyMock.createMock(HttpServletResponse.class);
         replay(response);
-        context = new ViewEngineContextImpl(null, null, null, response, null, null, null);
-        assertNotNull(context.getResponse());
+        context = new ViewEngineContextImpl(null, null, null, response, null, null, null, null, null, null);
+        assertNotNull(context.getResponse(Object.class));
         verify(response);
     }
 
@@ -87,11 +87,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetUriInfo() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, null, null);
         assertNull(context.getUriInfo());
         UriInfo uriInfo = EasyMock.createMock(UriInfo.class);
         replay(uriInfo);
-        context = new ViewEngineContextImpl(null, null, null, null, uriInfo, null, null);
+        context = new ViewEngineContextImpl(null, null, null, null, null, null, null, uriInfo, null, null);
         assertNotNull(context.getUriInfo());
         verify(uriInfo);
     }
@@ -101,11 +101,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetResourceInfo() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, null, null);
         assertNull(context.getResourceInfo());
         ResourceInfo resourceInfo = EasyMock.createMock(ResourceInfo.class);
         replay(resourceInfo);
-        context = new ViewEngineContextImpl(null, null, null, null, null, resourceInfo, null);
+        context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, resourceInfo, null);
         assertNotNull(context.getResourceInfo());
         verify(resourceInfo);
     }
@@ -115,11 +115,11 @@ public class ViewEngineContextImplTest {
      */
     @Test
     public void testGetConfiguration() {
-        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null);
+        ViewEngineContextImpl context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, null, null);
         assertNull(context.getConfiguration());
         Configuration config = EasyMock.createMock(Configuration.class);
         replay(config);
-        context = new ViewEngineContextImpl(null, null, null, null, null, null, config);
+        context = new ViewEngineContextImpl(null, null, null, null, null, null, null, null, null, config);
         assertNotNull(context.getConfiguration());
         verify(config);
     }

--- a/ext/asciidoc/src/main/java/org/mvcspec/ozark/ext/asciidoc/AsciiDocViewEngine.java
+++ b/ext/asciidoc/src/main/java/org/mvcspec/ozark/ext/asciidoc/AsciiDocViewEngine.java
@@ -15,10 +15,10 @@
  */
 package org.mvcspec.ozark.ext.asciidoc;
 
-import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.Asciidoctor.Factory;
 import org.asciidoctor.Options;
+import org.mvcspec.ozark.engine.ViewEngineBase;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -29,7 +29,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 
 /**
@@ -56,7 +58,8 @@ public class AsciiDocViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
-        try (PrintWriter writer = context.getResponse().getWriter();
+        Charset charset = resolveCharsetAndSetContentType(context);
+        try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset);
              InputStream is = servletContext.getResourceAsStream(resolveView(context));
              InputStreamReader isr = new InputStreamReader(is, "UTF-8");
              BufferedReader reader = new BufferedReader(isr)) {

--- a/ext/freemarker/src/main/java/org/mvcspec/ozark/ext/freemarker/FreemarkerViewEngine.java
+++ b/ext/freemarker/src/main/java/org/mvcspec/ozark/ext/freemarker/FreemarkerViewEngine.java
@@ -27,6 +27,8 @@ import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 
 /**
  * Class FreemarkerViewEngine.
@@ -47,10 +49,10 @@ public class FreemarkerViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
-        try {
+        Charset charset = resolveCharsetAndSetContentType(context);
+        try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
             final Template template = configuration.getTemplate(resolveView(context));
-            template.process(context.getModels(),
-                    new OutputStreamWriter(context.getResponse().getOutputStream()));
+            template.process(context.getModels(), writer);
         } catch (TemplateException | IOException e) {
             throw new ViewEngineException(e);
         }

--- a/ext/handlebars/src/main/java/org/mvcspec/ozark/ext/handlebars/HandlebarsViewEngine.java
+++ b/ext/handlebars/src/main/java/org/mvcspec/ozark/ext/handlebars/HandlebarsViewEngine.java
@@ -26,7 +26,13 @@ import javax.mvc.Models;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.stream.Collectors;
 
 /**
@@ -52,8 +58,9 @@ public class HandlebarsViewEngine extends ViewEngineBase {
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
         Models models = context.getModels();
+        Charset charset = resolveCharsetAndSetContentType(context);
 
-        try (PrintWriter writer = context.getResponse().getWriter();
+        try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset);
             InputStream resourceAsStream = servletContext.getResourceAsStream(resolveView(context));
             InputStreamReader in = new InputStreamReader(resourceAsStream, "UTF-8");
             BufferedReader bufferedReader = new BufferedReader(in);) {

--- a/ext/jade/src/main/java/org/mvcspec/ozark/ext/jade/JadeViewEngine.java
+++ b/ext/jade/src/main/java/org/mvcspec/ozark/ext/jade/JadeViewEngine.java
@@ -25,6 +25,9 @@ import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 
 /**
  * The Jade View Engine.
@@ -48,8 +51,9 @@ public class JadeViewEngine extends ViewEngineBase {
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
         String viewPath = resolveView(context);
-        try {
-            jade.renderTemplate(jade.getTemplate(viewPath), context.getModels(), context.getResponse().getWriter());
+        Charset charset = resolveCharsetAndSetContentType(context);
+        try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
+            jade.renderTemplate(jade.getTemplate(viewPath), context.getModels(), writer);
         } catch (JadeException | IOException ex) {
             throw new ViewEngineException(String.format("Could not process view %s.", context.getView()), ex);
         }

--- a/ext/mustache/src/main/java/org/mvcspec/ozark/ext/mustache/MustacheViewEngine.java
+++ b/ext/mustache/src/main/java/org/mvcspec/ozark/ext/mustache/MustacheViewEngine.java
@@ -25,7 +25,9 @@ import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 
 /**
  * Class MustacheViewEngine.
@@ -47,8 +49,8 @@ public class MustacheViewEngine extends ViewEngineBase {
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
         Mustache mustache = factory.compile(resolveView(context));
-        try {
-            Writer writer = context.getResponse().getWriter();
+        Charset charset = resolveCharsetAndSetContentType(context);
+        try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
             mustache.execute(writer, context.getModels()).flush();
         } catch (IOException e) {
             throw new ViewEngineException(e);

--- a/ext/pebble/src/main/java/org/mvcspec/ozark/ext/pebble/PebbleViewEngine.java
+++ b/ext/pebble/src/main/java/org/mvcspec/ozark/ext/pebble/PebbleViewEngine.java
@@ -23,6 +23,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import javax.inject.Inject;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
@@ -48,8 +51,9 @@ public class PebbleViewEngine extends ViewEngineBase {
   public void processView(ViewEngineContext context) throws ViewEngineException {
     String viewPath = resolveView(context);
 
-    try {
-      pebbleEngine.getTemplate(viewPath).evaluate(context.getResponse().getWriter(), context.getModels());
+    Charset charset = resolveCharsetAndSetContentType(context);
+    try(Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
+      pebbleEngine.getTemplate(viewPath).evaluate(writer, context.getModels());
     } catch (PebbleException | IOException ex) {
       throw new ViewEngineException(String.format("Could not process view %s.", context.getView()), ex);
     }

--- a/ext/stringtemplate/src/main/java/org/mvcspec/ozark/ext/stringtemplate/StringTemplateViewEngine.java
+++ b/ext/stringtemplate/src/main/java/org/mvcspec/ozark/ext/stringtemplate/StringTemplateViewEngine.java
@@ -22,7 +22,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.engine.*;
 import javax.servlet.ServletContext;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 
 import static java.util.regex.Pattern.compile;
@@ -47,8 +50,8 @@ public class StringTemplateViewEngine extends ViewEngineBase {
 	public void processView(ViewEngineContext context) throws ViewEngineException {
 		ST stringTemplate = getStringTemplate(resolveView(context));
 		context.getModels().forEach((key, value) -> add(key, value, stringTemplate));
-		try {
-			PrintWriter writer = context.getResponse().getWriter();
+		Charset charset = resolveCharsetAndSetContentType(context);
+		try(Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
 			stringTemplate.write(new AutoIndentWriter(writer));
 			stringTemplate.render();
 		} catch (Exception e) {

--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
@@ -52,8 +52,8 @@ public class ThymeleafViewEngine extends ViewEngineBase {
 	@Override
 	public void processView(ViewEngineContext context) throws ViewEngineException {
 		try {
-			HttpServletRequest request = context.getRequest();
-			HttpServletResponse response = context.getResponse();
+			HttpServletRequest request = context.getRequest(HttpServletRequest.class);
+			HttpServletResponse response = context.getResponse(HttpServletResponse.class);
 			WebContext ctx = new WebContext(request, response, servletContext, request.getLocale());
 			ctx.setVariables(context.getModels());
 			engine.process(resolveView(context), ctx, response.getWriter());

--- a/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/VelocityViewEngine.java
+++ b/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/VelocityViewEngine.java
@@ -15,17 +15,20 @@
  */
 package org.mvcspec.ozark.ext.velocity;
 
-import org.mvcspec.ozark.engine.ViewEngineBase;
-import org.mvcspec.ozark.engine.ViewEngineConfig;
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.mvcspec.ozark.engine.ViewEngineBase;
+import org.mvcspec.ozark.engine.ViewEngineConfig;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
 
 /**
  * Class VelocityViewEngine.
@@ -46,10 +49,11 @@ public class VelocityViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
-        try {
+        Charset charset = resolveCharsetAndSetContentType(context);
+        try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
             Template template = velocityEngine.getTemplate(resolveView(context));
             VelocityContext velocityContext = new VelocityContext(context.getModels());
-            template.merge(velocityContext, context.getResponse().getWriter());
+            template.merge(velocityContext, writer);
         } catch (IOException e) {
             throw new ViewEngineException(e);
         }


### PR DESCRIPTION
This pull request contains the required changes to support the new `ViewEngineContext` methods which were part of mvc-spec/mvc-spec#132.

I'll merge this today. Just want check if all the tests run fine. ;-)