### PR TITLE
Force Jersey to skip validation for MVC controllers

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
+            <version>8.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/org/mvcspec/ozark/cdi/OzarkCdiExtension.java
+++ b/core/src/main/java/org/mvcspec/ozark/cdi/OzarkCdiExtension.java
@@ -43,8 +43,10 @@ import org.mvcspec.ozark.uri.UriTemplateParser;
 import org.mvcspec.ozark.util.CdiUtils;
 import org.mvcspec.ozark.binding.validate.ValidationInterceptor;
 
+import javax.annotation.Priority;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.*;
+import javax.interceptor.Interceptor;
 import javax.mvc.annotation.Controller;
 import javax.mvc.annotation.RedirectScoped;
 import javax.mvc.event.MvcEvent;
@@ -158,9 +160,12 @@ public class OzarkCdiExtension implements Extension {
     }
 
     /**
-     * Search for {@link javax.mvc.annotation.Controller} annotation and patch AnnotatedType
+     * Search for {@link javax.mvc.annotation.Controller} annotation and patch AnnotatedType.
+     * Note: PLATFORM_AFTER is required so we execute AFTER the Hibernate Validator Extension
      */
-    public <T> void processAnnotatedType(@Observes @WithAnnotations({Controller.class}) ProcessAnnotatedType<T> pat) {
+    public <T> void processAnnotatedType(
+            @Observes @Priority(Interceptor.Priority.PLATFORM_AFTER) @WithAnnotations({Controller.class})
+                    ProcessAnnotatedType<T> pat) {
 
         AnnotatedType<T> replacement = annotatedTypeProcessor.getReplacement(pat.getAnnotatedType());
         if (replacement != null) {

--- a/core/src/main/java/org/mvcspec/ozark/cdi/types/AnnotatedMethodWrapper.java
+++ b/core/src/main/java/org/mvcspec/ozark/cdi/types/AnnotatedMethodWrapper.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Custom AnnotatedMethod implementation which wraps an existing instance and allows
@@ -38,10 +40,22 @@ public class AnnotatedMethodWrapper<T> implements AnnotatedMethod<T> {
 
     private final Set<Annotation> annotations = new LinkedHashSet<>();
 
-    public AnnotatedMethodWrapper(AnnotatedMethod<T> wrapped, Set<Annotation> additionalAnnotations) {
+    public AnnotatedMethodWrapper(AnnotatedMethod<T> wrapped,
+                                  Set<Annotation> additionalAnnotations,
+                                  Predicate<Class> annotationBlacklist) {
+
         this.wrapped = wrapped;
-        this.annotations.addAll(wrapped.getAnnotations());
+
+        // add annotations which are not blacklisted
+        this.annotations.addAll(
+                wrapped.getAnnotations().stream()
+                        .filter(a -> !annotationBlacklist.test(a.annotationType()))
+                        .collect(Collectors.toList())
+        );
+
+        // add additional annotations
         this.annotations.addAll(additionalAnnotations);
+
     }
 
     @Override

--- a/core/src/main/java/org/mvcspec/ozark/cdi/types/AnnotatedTypeProcessor.java
+++ b/core/src/main/java/org/mvcspec/ozark/cdi/types/AnnotatedTypeProcessor.java
@@ -75,8 +75,7 @@ public class AnnotatedTypeProcessor {
         Set<Annotation> markerAnnotations = Collections.singleton(() -> ValidationInterceptorBinding.class);
 
         // drop Hibernate Validator's marker annotations to skip the native validation
-        Predicate<Class> annotationBlacklist =
-                clazz -> clazz.getName().equals("org.hibernate.validator.cdi.internal.interceptor.MethodValidated");
+        Predicate<Class> annotationBlacklist = clazz -> isHibernateValidatorMarkerAnnotation(clazz);
 
         if (isResourceMethod && hasControllerAnnotation) {
 
@@ -91,6 +90,16 @@ public class AnnotatedTypeProcessor {
 
         return null;
 
+    }
+
+    private boolean isHibernateValidatorMarkerAnnotation(Class clazz) {
+        /*
+         * May be one of these classes depending on the exact Hibernate Validator version:
+         * org.hibernate.validator.cdi.internal.interceptor.MethodValidated
+         * org.hibernate.validator.internal.cdi.interceptor.MethodValidated
+         */
+        return clazz.getName().startsWith("org.hibernate.validator.")
+                && clazz.getName().endsWith(".interceptor.MethodValidated");
     }
 
 }

--- a/jersey/src/main/java/org/mvcspec/ozark/jersey/bootstrap/JerseyConfigProvider.java
+++ b/jersey/src/main/java/org/mvcspec/ozark/jersey/bootstrap/JerseyConfigProvider.java
@@ -17,6 +17,7 @@ package org.mvcspec.ozark.jersey.bootstrap;
 
 import org.mvcspec.ozark.bootstrap.ConfigProvider;
 import org.mvcspec.ozark.jersey.model.OzarkModelProcessor;
+import org.mvcspec.ozark.jersey.validation.OzarkValidationInterceptor;
 
 import javax.ws.rs.core.FeatureContext;
 
@@ -30,6 +31,7 @@ public class JerseyConfigProvider implements ConfigProvider {
     @Override
     public void configure(FeatureContext context) {
         context.register(OzarkModelProcessor.class);
+        context.register(OzarkValidationInterceptor.class);
     }
 
 }

--- a/jersey/src/main/java/org/mvcspec/ozark/jersey/validation/OzarkValidationInterceptor.java
+++ b/jersey/src/main/java/org/mvcspec/ozark/jersey/validation/OzarkValidationInterceptor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.jersey.validation;
+
+import org.glassfish.jersey.server.spi.ValidationInterceptor;
+import org.glassfish.jersey.server.spi.ValidationInterceptorContext;
+import org.mvcspec.ozark.util.AnnotationUtils;
+
+import javax.mvc.annotation.Controller;
+
+/**
+ * This interceptor prevents Jersey from performing validation for MVC requests. This
+ * is required because, we need to make sure that controller is always invoked as we
+ * are doing validation our self.
+ *
+ * @author Christian Kaltepoth
+ */
+public class OzarkValidationInterceptor implements ValidationInterceptor {
+
+    /**
+     * For some weird reason we cannot preserve the <code>throws ConstraintViolationException</code>
+     * in the method signature. Bundling Ozark as a Glassfish plugin starts failing as soon as
+     * this class uses any interface from the javax.validation package. My current guess is
+     * that this is related to the OSGi bundling.
+     */
+    @Override
+    public void onValidate(ValidationInterceptorContext context) {
+
+        /*
+         * TODO: Won't work correctly for mixed controller/resource methods.
+         */
+        Class<?> resourceClass = context.getResource().getClass();
+        boolean mvcRequest = AnnotationUtils.hasAnnotationOnClassOrMethod(resourceClass, Controller.class);
+
+        if (!mvcRequest) {
+            context.proceed();
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request will add a custom `ValidationInterceptor` to the Jersey module which will prevent Jersey from performing validation for MVC requests.

Unfortunately this still isn't enough to get rid of the `@ValidateOnExecution(NONE)` requirement because now the Hibernate Validation CDI interceptor will perform the validation. So by default Jersey actually performs manual validation of BV constraints before the Hibernate Validator CDI interceptor gets invoked, so the latter one will never fail because Jersey will abort processing before.

The good news is that if find a solution for the Hibernate Validation interceptor, we won't need  `@ValidateOnExecution(NONE)` for both Jersey and RESTEasy. And that would be AWESOME!

Travis CI, test please! ;-)