### PR TITLE
Skip RESTEasy validation for MVC controllers

### DIFF
--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -31,7 +31,7 @@
     <name>Ozark RESTEasy</name>
 
     <properties>
-        <resteasy.version>2.2.1.GA</resteasy.version>
+        <resteasy.version>3.1.4.Final</resteasy.version>
     </properties>
 
     <build>
@@ -87,6 +87,12 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
+            <version>${resteasy.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-validator-provider-11</artifactId>
             <version>${resteasy.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/resteasy/src/main/java/org/mvcspec/ozark/resteasy/bootstrap/RestEasyConfigProvider.java
+++ b/resteasy/src/main/java/org/mvcspec/ozark/resteasy/bootstrap/RestEasyConfigProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.resteasy.bootstrap;
+
+import org.mvcspec.ozark.bootstrap.ConfigProvider;
+import org.mvcspec.ozark.resteasy.validation.OzarkValidationResolver;
+
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Implementation of ConfigProvider for the RESTEasy module.
+ *
+ * @author Christian Kaltepoth
+ */
+public class RestEasyConfigProvider implements ConfigProvider {
+
+    @Override
+    public void configure(FeatureContext context) {
+        context.register(OzarkValidationResolver.class);
+    }
+
+}

--- a/resteasy/src/main/java/org/mvcspec/ozark/resteasy/validation/OzarkGeneralValidator.java
+++ b/resteasy/src/main/java/org/mvcspec/ozark/resteasy/validation/OzarkGeneralValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.resteasy.validation;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.validation.GeneralValidator;
+import org.mvcspec.ozark.util.AnnotationUtils;
+
+import javax.mvc.annotation.Controller;
+import java.lang.reflect.Method;
+
+/**
+ * Custom implementation of {@link GeneralValidator} which will ignore all
+ * validation requests for MVC controller.
+ *
+ * @author Christian Kaltepoth
+ */
+class OzarkGeneralValidator implements GeneralValidator {
+
+    private GeneralValidator delegate;
+
+    OzarkGeneralValidator(GeneralValidator delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean isValidatable(Class<?> clazz) {
+
+        // TODO: Won't work correctly for mixed controller/resource methods.
+        boolean mvcController =
+                AnnotationUtils.hasAnnotationOnClassOrMethod(clazz, Controller.class);
+
+        return !mvcController && delegate.isValidatable(clazz);
+
+    }
+
+    @Override
+    public boolean isMethodValidatable(Method method) {
+
+        // TODO: Won't work correctly for mixed controller/resource methods.
+        boolean mvcControllerMethod =
+                AnnotationUtils.hasAnnotationOnClassOrMethod(method.getDeclaringClass(), Controller.class);
+
+        return !mvcControllerMethod && delegate.isMethodValidatable(method);
+
+    }
+
+    @Override
+    public void validate(HttpRequest request, Object object, Class<?>... groups) {
+        delegate.validate(request, object, groups);
+    }
+
+    @Override
+    public void validateAllParameters(HttpRequest request, Object object, Method method, Object[] parameterValues, Class<?>... groups) {
+        delegate.validateAllParameters(request, object, method, parameterValues, groups);
+    }
+
+    @Override
+    public void validateReturnValue(HttpRequest request, Object object, Method method, Object returnValue, Class<?>... groups) {
+        delegate.validateReturnValue(request, object, method, returnValue, groups);
+    }
+
+    @Override
+    public void checkViolations(HttpRequest request) {
+        delegate.checkViolations(request);
+    }
+
+}

--- a/resteasy/src/main/java/org/mvcspec/ozark/resteasy/validation/OzarkValidationResolver.java
+++ b/resteasy/src/main/java/org/mvcspec/ozark/resteasy/validation/OzarkValidationResolver.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.resteasy.validation;
+
+import org.jboss.resteasy.plugins.validation.ValidatorContextResolver;
+import org.jboss.resteasy.spi.validation.GeneralValidator;
+
+import javax.ws.rs.ext.ContextResolver;
+
+/**
+ * This {@link ContextResolver} will resolve our own {@link GeneralValidator} which will ignore
+ * all validation requests for MVC controllers.
+ *
+ * @author Christian Kaltepoth
+ */
+public class OzarkValidationResolver implements ContextResolver<GeneralValidator> {
+
+    public GeneralValidator getContext(Class<?> aClass) {
+
+        // get the real RESTEasy validator
+        GeneralValidator wrapped = new ValidatorContextResolver().getContext(aClass);
+
+        // only delegate to wrapped validator for regular JAX-RS requests
+        return new OzarkGeneralValidator(wrapped);
+
+    }
+
+}

--- a/resteasy/src/main/resources/META-INF/services/org.mvcspec.ozark.bootstrap.ConfigProvider
+++ b/resteasy/src/main/resources/META-INF/services/org.mvcspec.ozark.bootstrap.ConfigProvider
@@ -1,0 +1,1 @@
+org.mvcspec.ozark.resteasy.bootstrap.RestEasyConfigProvider


### PR DESCRIPTION
This pull request will disable the RESTEasy validation for MVC controllers. There are still some TODOs, but it is basically working fine. This means that you won't need `@ValidateOnExecution(NONE)` any more on Wildfly and Tomcat with RESTEasy.
