### PR TITLE
Fixed check for 'void' return type

### DIFF
--- a/core/src/main/java/org/mvcspec/ozark/core/ViewResponseFilter.java
+++ b/core/src/main/java/org/mvcspec/ozark/core/ViewResponseFilter.java
@@ -128,7 +128,7 @@ public class ViewResponseFilter implements ContainerResponseFilter {
                 // If the entity is null the status will be set to 204 by Jersey. For void methods we need to
                 // set the status to 200 unless no other status was set by e.g. throwing an Exception.
                 responseContext.setStatusInfo(responseContext.getStatusInfo() == NO_CONTENT ? OK : responseContext.getStatusInfo());
-            } else if (returnType == Void.class) {
+            } else if (returnType == Void.TYPE) {
                 throw new ServerErrorException(messages.get("VoidControllerNoView", resourceInfo.getResourceMethod()), INTERNAL_SERVER_ERROR);
             }
         } else if (entityType != Viewable.class) {

--- a/test/annotations/src/test/java/org/mvcspec/ozark/test/annotations/AnnotationsIT.java
+++ b/test/annotations/src/test/java/org/mvcspec/ozark/test/annotations/AnnotationsIT.java
@@ -35,6 +35,7 @@ public class AnnotationsIT {
     public void setUp() {
         webUrl = System.getProperty("integration.url");
         webClient = new WebClient();
+        webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
     }
 
     @After
@@ -73,6 +74,6 @@ public class AnnotationsIT {
     @Test
     public void testNoOverrideMvc() throws Exception {
         final HtmlPage page = webClient.getPage(webUrl + "resources/annotations/no_override_mvc");
-        assertNull(page);       // Empty 204
+        assertEquals(500, page.getWebResponse().getStatusCode());       // void but no @View -> Exception
     }
 }


### PR DESCRIPTION
Ozark currently fails checking for the `void` return type. This one came up while working on the TCK.

Travis, check please!