### PR TITLE
Allow @MvcBinding on methods

### DIFF
--- a/core/src/main/java/org/mvcspec/ozark/binding/validate/ConstraintViolations.java
+++ b/core/src/main/java/org/mvcspec/ozark/binding/validate/ConstraintViolations.java
@@ -22,7 +22,11 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -83,17 +87,19 @@ public class ConstraintViolations {
 
     private static Annotation[] getPropertyAnnotations(ConstraintViolation<?> violation, Path.PropertyNode node) {
 
+        Class<?> leafBeanClass = violation.getLeafBean().getClass();
+        Set<Annotation> allAnnotations = new HashSet<>();
         try {
 
-            Class<?> leafBeanClass = violation.getLeafBean().getClass();
             Field field = leafBeanClass.getDeclaredField(node.getName());
-
-            return field.getAnnotations();
+            allAnnotations.addAll(Arrays.asList(field.getAnnotations()));
 
         } catch (NoSuchFieldException e) {
-            throw new IllegalStateException(e);
+            // ignore for now
         }
 
+        getterAnnotationsForField(leafBeanClass, node.getName()).ifPresent(g -> allAnnotations.addAll(Arrays.asList(g)));
+        return allAnnotations.toArray(new Annotation[0]);
     }
 
     private static Annotation[] getParameterAnnotations(ConstraintViolation<?> violation, Path.MethodNode methodNode,
@@ -116,6 +122,56 @@ public class ConstraintViolations {
             throw new IllegalStateException(e);
         }
 
+    }
+
+    private static Optional<Annotation[]> getterAnnotationsForField(Class<?> leafBeanClass, String fieldName) {
+        Method getter = null;
+        // try to determine our getter method
+        try {
+            // first try with getXXX()
+            getter = leafBeanClass.getDeclaredMethod(getMethodName(fieldName));
+        }
+        catch(final NoSuchMethodException e) {
+            // getXXX() didn't work so try isXXX()
+            try {
+                getter = leafBeanClass.getDeclaredMethod(isMethodName(fieldName));
+            }
+            catch(final NoSuchMethodException e1) {
+                // nothing to do
+            }
+        }
+
+        return (getter != null ? Optional.of(getter.getAnnotations()) : Optional.empty());
+    }
+
+    /**
+     * Takes a String propertyName and returns a String representation of what
+     * the getter-style accessor method for that property would be. So for
+     * propertyName <code>foo</code> the String <code>getFoo</code> will be
+     * returned.
+     *
+     * @param propertyName the property name
+     * @return String name of getter method
+     */
+    private static String getMethodName(final String propertyName) {
+        return generateMethodName(propertyName, "get");
+    }
+
+    /**
+     * Takes a String propertyName and returns a String representation of what
+     * the is-style accessor method for that property would be. So for
+     * propertyName <code>foo</code> the String <code>isFoo</code> will be
+     * returned.
+     *
+     * @param propertyName the property name
+     * @return String name of is method
+     */
+    private static String isMethodName(final String propertyName) {
+        return generateMethodName(propertyName, "is");
+    }
+
+    private static String generateMethodName(final String propertyName, final String prefix) {
+        return prefix + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
     }
 
 }


### PR DESCRIPTION
The first commit adds code to grab annotations from the getter method of a property and return them in addition to annotations found on the field. That gets the `@MvcBinding` annotation working so that it is picked up in ValidationInterceptor, but at this stage if you deploy an application like my example and force a validation error you'll see messages like these in the logs:
`WARNING [org.mvcspec.ozark.binding.validate.ValidationInterceptor] Cannot resolve paramName for violation: ConstraintViolationImpl{interpolatedMessage='size must be between 1 and      16', propertyPath=formPost.arg0.firstName, rootBeanClass=class eu.agilejava.mvc.HelloController$Proxy$_$$_WeldSubclass, messageTemplate='{javax.validation.constraints.Size.message}'}`

That message is coming from the fact that in my example I have the `@FormParam` annotated on the setter method for the property, and the commit above only checked the getter method for annotations. So we need to also check the setter for annotations, and the second commit does that.

As you can see from the code, I'm just doing some simple reflection to guess the getter and setter names. On the setter side, the code is currently expecting that only one `setXXX` method will be found in the bean, otherwise an exception will be thrown. There may be a way to determine the violated property's class from the ConstraintViolation to avoid that bit of guessing for the setter, but I didn't dig in deep enough to know for sure.

If you have any questions just let me know. Or if there are any changes that you'd like for me to make I'm happy to do that as well. I'm sure there are other ways to implement this sort of functionality. Thanks!