### PR TITLE
@MvcBinding on bean methods using java bean API

### DIFF
--- a/core/src/main/java/org/mvcspec/ozark/binding/validate/ConstraintViolations.java
+++ b/core/src/main/java/org/mvcspec/ozark/binding/validate/ConstraintViolations.java
@@ -18,11 +18,19 @@ package org.mvcspec.ozark.binding.validate;
 import javax.validation.ConstraintViolation;
 import javax.validation.ElementKind;
 import javax.validation.Path;
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -83,17 +91,20 @@ public class ConstraintViolations {
 
     private static Annotation[] getPropertyAnnotations(ConstraintViolation<?> violation, Path.PropertyNode node) {
 
+        Class<?> leafBeanClass = violation.getLeafBean().getClass();
+        Set<Annotation> allAnnotations = new HashSet<>();
         try {
 
-            Class<?> leafBeanClass = violation.getLeafBean().getClass();
             Field field = leafBeanClass.getDeclaredField(node.getName());
-
-            return field.getAnnotations();
+            allAnnotations.addAll(Arrays.asList(field.getAnnotations()));
 
         } catch (NoSuchFieldException e) {
-            throw new IllegalStateException(e);
+            // ignore for now
         }
 
+        allAnnotations.addAll(readAndWriteMethodAnnotationsForField(leafBeanClass, node.getName()));
+
+        return allAnnotations.toArray(new Annotation[0]);
     }
 
     private static Annotation[] getParameterAnnotations(ConstraintViolation<?> violation, Path.MethodNode methodNode,
@@ -116,6 +127,48 @@ public class ConstraintViolations {
             throw new IllegalStateException(e);
         }
 
+    }
+
+    /**
+     * Returns a set of all annotations present on the getter and setter methods
+     * for field fieldName in class beanClass. The bean class must be a valid
+     * java bean.
+     *
+     * @param beanClass the bean class
+     * @param fieldName the field in the bean class
+     * @return a set of all annotations on the read and write methods for the
+     * field, or an empty set if none are found
+     */
+    private static Set<Annotation> readAndWriteMethodAnnotationsForField(Class<?> beanClass, String fieldName) {
+        Set<Annotation> annotationsSet = new HashSet<>();
+
+        try {
+
+            BeanInfo info = Introspector.getBeanInfo(beanClass);
+
+            Optional<PropertyDescriptor> descriptorOpt = Arrays.stream(info.getPropertyDescriptors())
+                .filter(desc -> desc.getName().equals(fieldName))
+                .findFirst();
+
+            if(descriptorOpt.isPresent()) {
+
+                Method getter = descriptorOpt.get().getReadMethod();
+                if(getter != null) {
+                    annotationsSet.addAll(Arrays.asList(getter.getAnnotations()));
+                }
+
+                Method setter = descriptorOpt.get().getWriteMethod();
+                if(setter != null) {
+                    annotationsSet.addAll(Arrays.asList(setter.getAnnotations()));
+                }
+
+            }
+        }
+        catch(IntrospectionException e) {
+            // should we throw an exception here?
+        }
+
+        return annotationsSet;
     }
 
 }

--- a/test/constraintViolations/pom.xml
+++ b/test/constraintViolations/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mvc-spec.ozark.test</groupId>
+        <artifactId>ozark-parent-test</artifactId>
+        <version>1.0.0-m04-SNAPSHOT</version>
+    </parent>
+    <artifactId>constraintViolations</artifactId>
+    <packaging>war</packaging>
+    <name>Ozark Constraint Violations Tests</name>
+    <build>
+        <finalName>test-constraint-violations</finalName>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>6.0.9.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- hibernate validator needs el api and impl for tests -->
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>2.2.6</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/BaseUser.java
+++ b/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/BaseUser.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.test.constraintViolations;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+/**
+ * POJO bean for a user, with bean validation constraints on both a field and a
+ * getter method.
+ */
+public class BaseUser {
+
+    private String firstName;
+
+    @NotNull
+    @Size(max = 10)
+    private String lastName;
+
+    @NotNull
+    @Size(max = 10)
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/MvcUser.java
+++ b/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/MvcUser.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.test.constraintViolations;
+
+import javax.ws.rs.FormParam;
+
+/**
+ * Example MVC extension of BaseUser. The scenario is we have been provided the
+ * User class in some external library, and we're creating an MVC friendly
+ * model from that base object.
+ */
+public class MvcUser extends BaseUser {
+
+    @TestAnnotation
+    @Override
+    public String getFirstName() {
+        return super.getFirstName();
+    }
+
+    @FormParam("firstName")
+    @Override
+    public void setFirstName(String firstName) {
+        super.setFirstName(firstName);
+    }
+
+    @TestAnnotation
+    @Override
+    public String getLastName() {
+        return super.getLastName();
+    }
+
+    @FormParam("lastName")
+    @Override
+    public void setLastName(String lastName) {
+        super.setLastName(lastName);
+    }
+}

--- a/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/NotAJavaBean.java
+++ b/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/NotAJavaBean.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.test.constraintViolations;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.ws.rs.FormParam;
+
+/**
+ * A java class that is not a valid java bean.
+ */
+public class NotAJavaBean {
+
+    @FormParam("name")
+    @NotNull
+    @Size(max = 10)
+    private String name;
+
+    public NotAJavaBean(String name) {
+        this.name = name;
+    }
+
+    // invalid getter name per java beans spec
+    @TestAnnotation
+    public String name() {
+        return name;
+    }
+}

--- a/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/TestAnnotation.java
+++ b/test/constraintViolations/src/main/java/org/mvcspec/ozark/test/constraintViolations/TestAnnotation.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.test.constraintViolations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A test annotation that is taking the place of @MvcBinding for these tests.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD })
+@Documented
+public @interface TestAnnotation {
+    // empty
+}

--- a/test/constraintViolations/src/test/java/com/mvcspec/ozark/test/constraintViolations/ConstraintViolationsTest.java
+++ b/test/constraintViolations/src/test/java/com/mvcspec/ozark/test/constraintViolations/ConstraintViolationsTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mvcspec.ozark.test.constraintViolations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Pattern;
+import javax.ws.rs.FormParam;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mvcspec.ozark.binding.validate.ConstraintViolationMetadata;
+import org.mvcspec.ozark.binding.validate.ConstraintViolations;
+import org.mvcspec.ozark.test.constraintViolations.BaseUser;
+import org.mvcspec.ozark.test.constraintViolations.MvcUser;
+import org.mvcspec.ozark.test.constraintViolations.NotAJavaBean;
+import org.mvcspec.ozark.test.constraintViolations.TestAnnotation;
+
+/**
+ * Unit tests for annotation resolution in {@link ConstraintViolations}.
+ * <p>
+ * These tests are based on a scenario where we have a number of existing java
+ * bean classes that have bean validation constraints already applied to both
+ * fields and getter methods. We extend those beans so that we can annotate the
+ * field getter methods with {@link TestAnnotation} (which simulates the {@link
+ * javax.mvc.binding.MvcBinding} annotation), and annotate the setter methods
+ * with {@link javax.ws.rs.FormParam}, as would be done on a JAX-RS/MVC {@link
+ * javax.ws.rs.BeanParam}.
+ */
+public class ConstraintViolationsTest {
+
+    private static Validator validator;
+
+    /**
+     * Initialize our {@link Validator} instance.
+     */
+    @BeforeClass
+    public static void initValidator() {
+
+        final ValidatorFactory vf = Validation.buildDefaultValidatorFactory();
+        validator = vf.getValidator();
+
+    }
+
+    /**
+     * Create a valid {@link MvcUser} successfully, with no constraint
+     * violations.
+     */
+    @Test
+    public void validUserSuccess() {
+
+        final MvcUser mvcUser = new MvcUser();
+        mvcUser.setFirstName("John");
+        mvcUser.setLastName("Doe");
+
+        // validate the user - we should see no violations
+        final Set<ConstraintViolation<MvcUser>> errs = validator.validate(mvcUser);
+        assertNotNull(errs);
+        assertTrue("Expected no constraint violations for valid object", errs.isEmpty());
+
+    }
+
+    /**
+     * Create a {@link MvcUser} with an invalid first name.
+     * <p>
+     * This tests a bean validation constraint applied to the getter method of
+     * the field in the {@link BaseUser} superclass.
+     */
+    @Test
+    public void invalidMvcUserFirstNameSuccess() {
+
+        // create a user with a first name longer than 10 characters
+        final MvcUser mvcUser = new MvcUser();
+        mvcUser.setFirstName("A first name that is longer than 10");
+        mvcUser.setLastName("Doe");
+
+        // validate the user - we should see 1 violation due to the long first name
+        final Set<ConstraintViolation<MvcUser>> errs = validator.validate(mvcUser);
+        assertNotNull(errs);
+        assertEquals("Expect 1 constraint violation from validation", errs.size(), 1);
+
+        // create the metadata for our violation
+        final ConstraintViolation<MvcUser> violation = errs.iterator().next();
+        final ConstraintViolationMetadata metadata = ConstraintViolations.getMetadata(violation);
+        assertNotNull("Violation metadata should not be null", metadata);
+
+        // verify that firstName was the violated JAX-RS/MVC param
+        final Optional<String> metadataViolatedParamName = metadata.getParamName();
+        assertTrue("Violation metadata should contain the violated param name", metadataViolatedParamName.isPresent());
+        assertEquals("Metadata violated param should be 'firstName'", "firstName", metadataViolatedParamName.get());
+
+        // lastly, test for our MVC-ish annotations based on our constraint violation
+        // metadata. we should find @TestAnnotation from the getter method for firstName,
+        // and @FormParam from the setter. Also test for annotations that we expect to
+        // NOT be present
+        assertTrue("@TestAnnotation should be found on 'firstName'", metadata.hasAnnotation(TestAnnotation.class));
+        assertTrue("@FormParam should be found on 'firstName'", metadata.hasAnnotation(FormParam.class));
+        assertFalse("@Pattern should not be found on 'firstName'", metadata.hasAnnotation(Pattern.class));
+
+    }
+
+    /**
+     * Create a {@link MvcUser} with an invalid last name.
+     * <p>
+     * This tests a bean validation constraint applied to the field of our
+     * {@link BaseUser} superclass.
+     */
+    @Test
+    public void invalidMvcUserLastNameSuccess() {
+
+        // create a user with a last name longer than 10 characters
+        final MvcUser mvcUser = new MvcUser();
+        mvcUser.setFirstName("John");
+        mvcUser.setLastName("A last name longer than 10");
+
+        // validate the user - we should see 1 violation due to the long last name
+        final Set<ConstraintViolation<MvcUser>> errs = validator.validate(mvcUser);
+        assertNotNull(errs);
+        assertEquals("Expect 1 constraint violation from validation", errs.size(), 1);
+
+        // create the metadata for our violation
+        final ConstraintViolation<MvcUser> violation = errs.iterator().next();
+        final ConstraintViolationMetadata metadata = ConstraintViolations.getMetadata(violation);
+        assertNotNull("Violation metadata should not be null", metadata);
+
+        // verify that lastName was the violated JAX-RS/MVC param
+        final Optional<String> metadataViolatedParamName = metadata.getParamName();
+        assertTrue("Violation metadata should contain the violated param name", metadataViolatedParamName.isPresent());
+        assertEquals("Metadata violated param should be 'lastName'", "lastName", metadataViolatedParamName.get());
+
+        // lastly, test for our MVC-ish annotations based on our constraint violation
+        // metadata. we should find @TestAnnotation from the getter method for lastName,
+        // and @FormParam from the setter. Also test for annotations that we expect to
+        // NOT be present
+        assertTrue("@TestAnnotation should be found on 'lastName'", metadata.hasAnnotation(TestAnnotation.class));
+        assertTrue("@FormParam should be found on 'lastName'", metadata.hasAnnotation(FormParam.class));
+        assertFalse("@Pattern should not be found on 'lastName'", metadata.hasAnnotation(Pattern.class));
+
+    }
+
+    /**
+     * Test a constraint violation on an object that does use a bean validation
+     * constraint on a field, but is NOT a valid java bean.
+     * <p>
+     * This test simply ensures that our metadata generation methods in {@link
+     * ConstraintViolations} work even when passed an object that is not a java
+     * bean.
+     */
+    @Test
+    public void notAJavaBeanSuccess() {
+
+        final NotAJavaBean nonJavaBean = new NotAJavaBean("Value that is more than 10");
+
+        // validate the class - we should see 1 violation due to the long name
+        final Set<ConstraintViolation<NotAJavaBean>> errs = validator.validate(nonJavaBean);
+        assertNotNull(errs);
+        assertEquals("Expect 1 constraint violation from validation", errs.size(), 1);
+
+        // create the metadata for our violation. we should have no problem even though
+        // we're not dealing with a valid java bean object
+        final ConstraintViolation<NotAJavaBean> violation = errs.iterator().next();
+        final ConstraintViolationMetadata metadata = ConstraintViolations.getMetadata(violation);
+        assertNotNull("Violation metadata should not be null", metadata);
+
+        // our metadata should be able to resolve our violated param name properly
+        // (the property 'name' has the annotation @FormParam), but it won't be able to
+        // locate the @TestAnnotation on the name() method since it is not a valid
+        // java beans getter.
+        final Optional<String> metadataViolatedParamName = metadata.getParamName();
+        assertTrue("Violation metadata should contain the violated field name", metadataViolatedParamName.isPresent());
+        assertEquals("Metadata violated field should be 'name'", "name", metadataViolatedParamName.get());
+        assertFalse("@TestAnnotation should not be found on 'name'", metadata.hasAnnotation(TestAnnotation.class));
+
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -85,6 +85,7 @@
         <module>pebble</module>
         <module>uri-builder</module>
         <module>jetbrick</module>
+        <module>constraintViolations</module>
     </modules>
     <profiles>
         <profile>


### PR DESCRIPTION
Here's attempt number two at getting `@MvcBinding` working on bean methods.

The first commit is nothing more than unit tests for `ConstraintViolations`, based on the superclass and subclass example that I originally posted to the mailing list. If you run the tests at this point they will fail with a `NoSuchFieldException` being thrown from `ConstraintViolations`.

The second commit is the new fix, using the `java.beans` API rather than low-level reflection to discover getter and setter methods and annotations on those methods. The unit tests are all successful after the fix.

Lastly, I wanted to address your comment about potentially throwing an exception when we encounter a `NoSuchFieldException`. I think we do not want to throw an exception in that case, because the field lookup will always fail with a `NoSuchFieldException` in the case of a subclass that only overrides methods from the super class. I created a unit test that illustrates this and put it in this gist [1]. I can add it in to the code base if you want, but since it really does nothing more than verify behavior of the JRE I didn't know if it was worth including.

Let me know if you have any questions or would like for me to make any other changes. I'm happy to help!

[1] https://gist.github.com/cdollar393/7e277029ac06ee5b2af9016d61fb0090