### PR TITLE
Adjust mvc context

### DIFF
--- a/core/src/main/java/org/mvcspec/ozark/MvcContextImpl.java
+++ b/core/src/main/java/org/mvcspec/ozark/MvcContextImpl.java
@@ -85,21 +85,11 @@ public class MvcContextImpl implements MvcContext {
     }
 
     @Override
-    public String getContextPath() {
-        return servletContext.getContextPath();   // normalized by servlet
-    }
-
-    @Override
-    public String getApplicationPath() {
-        return applicationPath;
-    }
-
-    @Override
     public String getBasePath() {
-        if (getApplicationPath() != null) {
-            return getContextPath() + getApplicationPath();
+        if (applicationPath != null) {
+            return servletContext.getContextPath() + applicationPath;
         }
-        return getContextPath();
+        return servletContext.getContextPath();
     }
 
     @Override

--- a/core/src/main/java/org/mvcspec/ozark/cdi/RedirectScopeManager.java
+++ b/core/src/main/java/org/mvcspec/ozark/cdi/RedirectScopeManager.java
@@ -252,7 +252,7 @@ public class RedirectScopeManager {
         if (request.getAttribute(SCOPE_ID) != null) {
             if (usingCookies()) {
                 Cookie cookie = new Cookie(COOKIE_NAME, request.getAttribute(SCOPE_ID).toString());
-                cookie.setPath(mvc.getContextPath());
+                cookie.setPath(request.getContextPath());
                 cookie.setMaxAge(600);
                 cookie.setHttpOnly(true);
                 response.addCookie(cookie);

--- a/ext/freemarker/src/main/java/org/mvcspec/ozark/ext/freemarker/FreemarkerViewEngine.java
+++ b/ext/freemarker/src/main/java/org/mvcspec/ozark/ext/freemarker/FreemarkerViewEngine.java
@@ -15,20 +15,23 @@
  */
 package org.mvcspec.ozark.ext.freemarker;
 
-import org.mvcspec.ozark.engine.ViewEngineBase;
-import org.mvcspec.ozark.engine.ViewEngineConfig;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
+import org.mvcspec.ozark.engine.ViewEngineBase;
+import org.mvcspec.ozark.engine.ViewEngineConfig;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class FreemarkerViewEngine.
@@ -49,10 +52,18 @@ public class FreemarkerViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
+
         Charset charset = resolveCharsetAndSetContentType(context);
+
         try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
-            final Template template = configuration.getTemplate(resolveView(context));
-            template.process(context.getModels(), writer);
+
+            Template template = configuration.getTemplate(resolveView(context));
+
+            Map<String, Object> model = new HashMap<>(context.getModels());
+            model.put("request", context.getRequest(HttpServletRequest.class));
+
+            template.process(model, writer);
+
         } catch (TemplateException | IOException e) {
             throw new ViewEngineException(e);
         }

--- a/ext/jade/src/main/java/org/mvcspec/ozark/ext/jade/JadeViewEngine.java
+++ b/ext/jade/src/main/java/org/mvcspec/ozark/ext/jade/JadeViewEngine.java
@@ -17,6 +17,7 @@ package org.mvcspec.ozark.ext.jade;
 
 import de.neuland.jade4j.JadeConfiguration;
 import de.neuland.jade4j.exceptions.JadeException;
+import de.neuland.jade4j.template.JadeTemplate;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
@@ -24,10 +25,13 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The Jade View Engine.
@@ -50,10 +54,18 @@ public class JadeViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
-        String viewPath = resolveView(context);
+
         Charset charset = resolveCharsetAndSetContentType(context);
+
         try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
-            jade.renderTemplate(jade.getTemplate(viewPath), context.getModels(), writer);
+
+            JadeTemplate template = jade.getTemplate(resolveView(context));
+
+            Map<String, Object> model = new HashMap<>(context.getModels());
+            model.put("request", context.getRequest(HttpServletRequest.class));
+
+            jade.renderTemplate(template, model, writer);
+
         } catch (JadeException | IOException ex) {
             throw new ViewEngineException(String.format("Could not process view %s.", context.getView()), ex);
         }

--- a/ext/jetbrick/src/main/java/org/mvcspec/ozark/ext/jetbrick/JetbrickViewEngine.java
+++ b/ext/jetbrick/src/main/java/org/mvcspec/ozark/ext/jetbrick/JetbrickViewEngine.java
@@ -27,10 +27,13 @@ import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Daniel Dias
@@ -55,10 +58,18 @@ public class JetbrickViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
+
         Charset charset = resolveCharsetAndSetContentType(context);
+
         try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
+
             JetTemplate template = jetEngine.getTemplate(resolveView(context));
-            template.render(context.getModels(), writer);
+
+            Map<String, Object> model = new HashMap<>(context.getModels());
+            model.put("request", context.getRequest(HttpServletRequest.class));
+
+            template.render(model, writer);
+
         } catch (TemplateException | IOException e) {
             throw new ViewEngineException(e);
         }

--- a/ext/mustache/src/main/java/org/mvcspec/ozark/ext/mustache/MustacheViewEngine.java
+++ b/ext/mustache/src/main/java/org/mvcspec/ozark/ext/mustache/MustacheViewEngine.java
@@ -24,10 +24,13 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class MustacheViewEngine.
@@ -48,10 +51,18 @@ public class MustacheViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
-        Mustache mustache = factory.compile(resolveView(context));
+
         Charset charset = resolveCharsetAndSetContentType(context);
+
         try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
-            mustache.execute(writer, context.getModels()).flush();
+
+            Mustache mustache = factory.compile(resolveView(context));
+
+            Map<String, Object> model = new HashMap<>(context.getModels());
+            model.put("request", context.getRequest(HttpServletRequest.class));
+
+            mustache.execute(writer, model).flush();
+
         } catch (IOException e) {
             throw new ViewEngineException(e);
         }

--- a/ext/pebble/src/main/java/org/mvcspec/ozark/ext/pebble/PebbleViewEngine.java
+++ b/ext/pebble/src/main/java/org/mvcspec/ozark/ext/pebble/PebbleViewEngine.java
@@ -17,6 +17,7 @@ package org.mvcspec.ozark.ext.pebble;
 
 import com.mitchellbosecke.pebble.PebbleEngine;
 import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -26,7 +27,11 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
 /**
@@ -49,11 +54,18 @@ public class PebbleViewEngine extends ViewEngineBase {
 
   @Override
   public void processView(ViewEngineContext context) throws ViewEngineException {
-    String viewPath = resolveView(context);
 
     Charset charset = resolveCharsetAndSetContentType(context);
+    
     try(Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
-      pebbleEngine.getTemplate(viewPath).evaluate(writer, context.getModels());
+
+      PebbleTemplate template = pebbleEngine.getTemplate(resolveView(context));
+      
+      Map<String, Object> model = new HashMap<>(context.getModels());
+      model.put("request", context.getRequest(HttpServletRequest.class));
+      
+      template.evaluate(writer, model);
+      
     } catch (PebbleException | IOException ex) {
       throw new ViewEngineException(String.format("Could not process view %s.", context.getView()), ex);
     }

--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
@@ -28,6 +28,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class Thymeleaf ViewEngine.
@@ -51,12 +53,19 @@ public class ThymeleafViewEngine extends ViewEngineBase {
 
 	@Override
 	public void processView(ViewEngineContext context) throws ViewEngineException {
+		
 		try {
+			
 			HttpServletRequest request = context.getRequest(HttpServletRequest.class);
 			HttpServletResponse response = context.getResponse(HttpServletResponse.class);
 			WebContext ctx = new WebContext(request, response, servletContext, request.getLocale());
-			ctx.setVariables(context.getModels());
+
+			Map<String, Object> model = new HashMap<>(context.getModels());
+			model.put("request", request);
+			ctx.setVariables(model);
+			
 			engine.process(resolveView(context), ctx, response.getWriter());
+			
 		} catch (IOException e) {
 			throw new ViewEngineException(e);
 		}

--- a/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/VelocityViewEngine.java
+++ b/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/VelocityViewEngine.java
@@ -25,10 +25,13 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Class VelocityViewEngine.
@@ -49,11 +52,19 @@ public class VelocityViewEngine extends ViewEngineBase {
 
     @Override
     public void processView(ViewEngineContext context) throws ViewEngineException {
+        
         Charset charset = resolveCharsetAndSetContentType(context);
+        
         try (Writer writer = new OutputStreamWriter(context.getOutputStream(), charset)) {
+            
             Template template = velocityEngine.getTemplate(resolveView(context));
-            VelocityContext velocityContext = new VelocityContext(context.getModels());
+
+            Map<String, Object> model = new HashMap<>(context.getModels());
+            model.put("request", context.getRequest(HttpServletRequest.class));
+            VelocityContext velocityContext = new VelocityContext(model);
+            
             template.merge(velocityContext, writer);
+            
         } catch (IOException e) {
             throw new ViewEngineException(e);
         }

--- a/test/annotations/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/annotations/src/main/webapp/WEB-INF/views/error.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Error</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Error</h1>

--- a/test/annotations/src/main/webapp/WEB-INF/views/success.jsp
+++ b/test/annotations/src/main/webapp/WEB-INF/views/success.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Success</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Success</h1>

--- a/test/book-cdi/src/main/webapp/WEB-INF/views/book.jsp
+++ b/test/book-cdi/src/main/webapp/WEB-INF/views/book.jsp
@@ -3,7 +3,7 @@
 <html>
     <head>
         <title>Book Information</title>
-        <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css">
+        <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css">
     </head>
     <body>
     <h1>Book Information</h1>

--- a/test/book-models/src/main/webapp/WEB-INF/views/book.jsp
+++ b/test/book-models/src/main/webapp/WEB-INF/views/book.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Book Information</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Book Information</h1>

--- a/test/conversation/src/main/webapp/WEB-INF/views/start.jsp
+++ b/test/conversation/src/main/webapp/WEB-INF/views/start.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Starting Conversation</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Starting Conversation</h1>

--- a/test/conversation/src/main/webapp/WEB-INF/views/stop.jsp
+++ b/test/conversation/src/main/webapp/WEB-INF/views/stop.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Stopping Conversation</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Stopping Conversation</h1>

--- a/test/conversation/src/main/webapp/WEB-INF/views/tellme.jsp
+++ b/test/conversation/src/main/webapp/WEB-INF/views/tellme.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>In Conversation</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>In Conversation</h1>

--- a/test/csrf-property/src/main/webapp/WEB-INF/views/csrf.jsp
+++ b/test/csrf-property/src/main/webapp/WEB-INF/views/csrf.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection Test</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection Test</h1>

--- a/test/csrf-property/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/csrf-property/src/main/webapp/WEB-INF/views/error.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection Error</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection Failed</h1>

--- a/test/csrf-property/src/main/webapp/WEB-INF/views/ok.jsp
+++ b/test/csrf-property/src/main/webapp/WEB-INF/views/ok.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection OK</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection OK</h1>

--- a/test/csrf/src/main/webapp/WEB-INF/views/csrf.jsp
+++ b/test/csrf/src/main/webapp/WEB-INF/views/csrf.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection Test</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection Test</h1>

--- a/test/csrf/src/main/webapp/WEB-INF/views/ok.jsp
+++ b/test/csrf/src/main/webapp/WEB-INF/views/ok.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection OK</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection OK</h1>

--- a/test/events/src/main/webapp/WEB-INF/views/event.jsp
+++ b/test/events/src/main/webapp/WEB-INF/views/event.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>MVC Events</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Event Information</h1>

--- a/test/exceptions/src/main/webapp/WEB-INF/views/bye.jsp
+++ b/test/exceptions/src/main/webapp/WEB-INF/views/bye.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Bye World</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Bye World</h1>

--- a/test/exceptions/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/exceptions/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>

--- a/test/facelets/src/main/webapp/book.xhtml
+++ b/test/facelets/src/main/webapp/book.xhtml
@@ -4,7 +4,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html">
     <h:head>
         <title>Book Information</title>
-        <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+        <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     </h:head>
     <h:body>
         <h1>Book Information</h1>

--- a/test/facelets/src/main/webapp/index.html
+++ b/test/facelets/src/main/webapp/index.html
@@ -3,7 +3,7 @@
     <head>
         <title>Book Controllers using Facelets</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+        <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     </head>
     <body>
         <h1>Book Controllers using Facelets</h1>

--- a/test/freemarker/src/main/webapp/WEB-INF/views/hello.ftl
+++ b/test/freemarker/src/main/webapp/WEB-INF/views/hello.ftl
@@ -1,7 +1,7 @@
 <html>
     <head>
       <title>Hello There</title>
-        <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+        <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     </head>
     <body>
       <h1>Hello ${user?html}!</h1>

--- a/test/handlebars/src/main/webapp/WEB-INF/views/person.hbs
+++ b/test/handlebars/src/main/webapp/WEB-INF/views/person.hbs
@@ -3,7 +3,7 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title>Person View</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Person</h1>

--- a/test/jade/src/main/webapp/WEB-INF/views/config.jade
+++ b/test/jade/src/main/webapp/WEB-INF/views/config.jade
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title= pageName
-    link(rel='stylesheet', href='#{mvc.contextPath}/ozark.css')
+    link(rel='stylesheet', href='#{request.contextPath}/ozark.css')
   body
     :systemProperties
       SystemProperties

--- a/test/jade/src/main/webapp/WEB-INF/views/helper.jade
+++ b/test/jade/src/main/webapp/WEB-INF/views/helper.jade
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title= pageName
-    link(rel='stylesheet', href='#{mvc.contextPath}/ozark.css')
+    link(rel='stylesheet', href='#{request.contextPath}/ozark.css')
   body
     h1 Hello Helper
     p.result= math.round(3.14159)

--- a/test/jade/src/main/webapp/WEB-INF/views/main.jade
+++ b/test/jade/src/main/webapp/WEB-INF/views/main.jade
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title= pageName
-    link(rel='stylesheet', href='#{mvc.contextPath}/ozark.css')
+    link(rel='stylesheet', href='#{request.contextPath}/ozark.css')
   body
     h1 Hello #{user}
   include includes/footer.jade

--- a/test/jade/src/main/webapp/WEB-INF/views/markdown.jade
+++ b/test/jade/src/main/webapp/WEB-INF/views/markdown.jade
@@ -2,7 +2,7 @@ doctype html
 html
   head
     title= pageName
-    link(rel='stylesheet', href='#{mvc.contextPath}/ozark.css')
+    link(rel='stylesheet', href='#{request.contextPath}/ozark.css')
   body
     :markdown
       # Mardown introduction

--- a/test/jetbrick/src/main/webapp/WEB-INF/views/hello.jetx
+++ b/test/jetbrick/src/main/webapp/WEB-INF/views/hello.jetx
@@ -3,7 +3,7 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title>Hello</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Hello ${user}!</h1>

--- a/test/locale/src/main/webapp/WEB-INF/views/locale.jsp
+++ b/test/locale/src/main/webapp/WEB-INF/views/locale.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     <title>Request Locale</title>
 </head>
 <body>

--- a/test/mustache/src/main/webapp/WEB-INF/views/hello.mustache
+++ b/test/mustache/src/main/webapp/WEB-INF/views/hello.mustache
@@ -1,7 +1,7 @@
 <html>
     <head>
       <title>Hello</title>
-      <link rel="stylesheet" type="text/css" href="{{mvc.contextPath}}/ozark.css"/>
+      <link rel="stylesheet" type="text/css" href="{{request.contextPath}}/ozark.css"/>
     </head>
     <body>
       <h1>Hello {{user}}!</h1>

--- a/test/mvc/src/main/webapp/WEB-INF/views/mvc.jsp
+++ b/test/mvc/src/main/webapp/WEB-INF/views/mvc.jsp
@@ -3,12 +3,11 @@
 <html>
 <head>
     <title>Mvc Test</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Mvc Test</h1>
-    <p id="contextPath">${mvc.contextPath}</p>
-    <p id="applicationPath">${mvc.applicationPath}</p>
+    <p id="basePath">${mvc.basePath}</p>
     <p id="csrf">${mvc.csrf.name}</p>
     <p id="encoders">${mvc.encoders.html("<&>")}</p>
     <p id="config">${mvc.config.properties.get("myproperty")}</p>

--- a/test/mvc/src/test/java/org/mvcspec/ozark/test/mvc/MvcIT.java
+++ b/test/mvc/src/test/java/org/mvcspec/ozark/test/mvc/MvcIT.java
@@ -49,8 +49,7 @@ public class MvcIT {
     @Test
     public void test() throws Exception {
         HtmlPage page = webClient.getPage(webUrl + "resources/mvc");
-        assertEquals("/test-mvc", page.getElementById("contextPath").asText());
-        assertEquals("/resources", page.getElementById("applicationPath").asText());
+        assertEquals("/test-mvc/resources", page.getElementById("basePath").asText());
         assertEquals(CSRF_PARAM, page.getElementById("csrf").asText());
         assertEquals("<&>", page.getElementById("encoders").asText());
         assertEquals("true", page.getElementById("config").asText());

--- a/test/produces/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/produces/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>

--- a/test/redirect/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/redirect/src/main/webapp/WEB-INF/views/error.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Redirect Event not reported!</h1>

--- a/test/redirect/src/main/webapp/WEB-INF/views/redirect.jsp
+++ b/test/redirect/src/main/webapp/WEB-INF/views/redirect.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Redirect Works!</h1>

--- a/test/redirectScope/src/main/webapp/WEB-INF/views/redirect.jsp
+++ b/test/redirectScope/src/main/webapp/WEB-INF/views/redirect.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css">
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css">
 </head>
 <body>
     <h1>Redirect Works!</h1>

--- a/test/redirectScope2/src/main/webapp/WEB-INF/views/redirect.jsp
+++ b/test/redirectScope2/src/main/webapp/WEB-INF/views/redirect.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css">
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css">
 </head>
 <body>
     <h1>Redirect Works!</h1>

--- a/test/returns/src/main/webapp/WEB-INF/views/bye.jsp
+++ b/test/returns/src/main/webapp/WEB-INF/views/bye.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Bye World</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Bye World</h1>

--- a/test/returns/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/returns/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>

--- a/test/thymeleaf/src/main/webapp/WEB-INF/views/hello.html
+++ b/test/thymeleaf/src/main/webapp/WEB-INF/views/hello.html
@@ -1,7 +1,7 @@
 <html>
     <head>
       <title>Hello</title>
-      <link rel="stylesheet" type="text/css" th:href="@{~{cp}/ozark.css(cp=${mvc.contextPath})}" />
+      <link rel="stylesheet" type="text/css" th:href="@{~{cp}/ozark.css(cp=${request.contextPath})}" />
     </head>
     <body>
       <h1>Hello <span th:text="${user}"/>!</h1>

--- a/test/uri-builder/src/main/webapp/WEB-INF/views/uri-builder.jsp
+++ b/test/uri-builder/src/main/webapp/WEB-INF/views/uri-builder.jsp
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <title>MvcUriBuilder examples</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <div class="container">

--- a/test/validation-i18n/src/main/webapp/WEB-INF/views/form.jsp
+++ b/test/validation-i18n/src/main/webapp/WEB-INF/views/form.jsp
@@ -3,7 +3,7 @@
 <!doctype html>
 <html>
     <head>
-        <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+        <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
         <title>Validation</title>
     </head>
     <body>

--- a/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     <title>Form Binding Error</title>
 </head>
 <body>

--- a/test/validation/src/main/webapp/WEB-INF/views/data.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/data.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     <title>Form Validation</title>
 </head>
 <body>

--- a/test/validation/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/error.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     <title>Form Validation</title>
 </head>
 <body>

--- a/test/velocity/src/main/webapp/WEB-INF/views/hello.vm
+++ b/test/velocity/src/main/webapp/WEB-INF/views/hello.vm
@@ -1,7 +1,7 @@
 <html>
     <head>
       <title>Hello</title>
-      <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+      <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
     </head>
     <body>
       <h1>Hello $mvc.encoders.html($user)!</h1>

--- a/test/view-annotation/src/main/webapp/WEB-INF/views/bye.jsp
+++ b/test/view-annotation/src/main/webapp/WEB-INF/views/bye.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Bye World</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Bye World</h1>

--- a/test/view-annotation/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/view-annotation/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${mvc.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>


### PR DESCRIPTION
The pull request contains the following changes:

 * `MvcContextImpl` is adjusted according to the recent changes to the interface.
 * Most 3rd party view engines provide access to the `HttpServletRequest` by storing it manually in the model.
 * All tests were adjusted to don't use `${mvc.contextPath}` any more