### PR TITLE
resolve cdi-named-beans in thymeleaf

### DIFF
--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/CDIWebContext.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/CDIWebContext.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.ext.thymeleaf;
+
+import org.thymeleaf.context.IWebContext;
+import org.thymeleaf.context.LazyContextVariable;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Thymeleaf context for resolving variables from the model or cdi context. In addition to the functions provided by
+ * {@link org.thymeleaf.context.WebContext} this allows to resolve beans annotated with {@linkplain javax.inject.Named}
+ * from the cdi context.
+ * <p>
+ * Beans will be reolved in this order:
+ * <ol>
+ *     <li>special variables (like "request")</li>
+ *     <li>variables from the model</li>
+ *     <li>named beans from the cdi context</li>
+ * </ol>
+ * </p>
+ *
+ * @author Gregor Tudan
+ */
+class CDIWebContext implements IWebContext {
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final ServletContext context;
+    private final Locale locale;
+
+    private final BeanManager beanManager;
+    private final Set<String> cdiNamedBeans;
+
+    private final Map<String, Object> variables = new HashMap<>();
+
+    CDIWebContext(BeanManager beanManager, HttpServletRequest request, HttpServletResponse response, ServletContext servletContext, Locale locale) {
+        this.beanManager = beanManager;
+        this.request = request;
+        this.response = response;
+        this.context = servletContext;
+        this.locale = locale;
+        this.cdiNamedBeans = enumerateNamedBeans();
+    }
+
+    @SuppressWarnings("serial")
+    private Set<String> enumerateNamedBeans() {
+        Set<Bean<?>> beans = beanManager.getBeans(Object.class, new AnnotationLiteral<Any>() { });
+        return beans.stream().map(Bean::getName).filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
+    @Override
+    public HttpServletRequest getRequest() {
+        return request;
+    }
+
+    @Override
+    public HttpServletResponse getResponse() {
+        return response;
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return request.getSession();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return context;
+    }
+
+    @Override
+    public Locale getLocale() {
+        return locale;
+    }
+
+    @Override
+    public boolean containsVariable(String name) {
+        Objects.requireNonNull(name, "The variable name must not be null");
+        if (variables.containsKey(name)) {
+            return true;
+        }
+        return cdiNamedBeans.contains(name);
+    }
+
+    @Override
+    public Set<String> getVariableNames() {
+        final Set<String> variableNames = new HashSet<>(variables.keySet());
+        variableNames.addAll(this.cdiNamedBeans);
+        return variableNames;
+    }
+
+    @Override
+    public Object getVariable(String name) {
+        Objects.requireNonNull(name, "The variable name must not be null");
+        if (variables.containsKey(name)) {
+            return variables.get(name);
+        } else if (cdiNamedBeans.contains(name)) {
+            return getCdiBean(name);
+        } else {
+            return null;
+        }
+    }
+
+    private Object getCdiBean(String name) {
+        return new LazyContextVariable<Object>() {
+            @Override
+            protected Object loadValue() {
+                Bean<?> bean = beanManager.getBeans(name).iterator().next();
+                CreationalContext ctx = beanManager.createCreationalContext(bean);
+                return beanManager.getReference(bean, bean.getBeanClass(), ctx);
+            }
+        };
+    }
+
+    void setVariables(Map<String, Object> variables) {
+        this.variables.clear();
+        if (variables != null) {
+            this.variables.putAll(variables);
+        }
+    }
+}

--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/CDIWebContext.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/CDIWebContext.java
@@ -84,7 +84,7 @@ class CDIWebContext implements IWebContext {
 
     @Override
     public HttpSession getSession() {
-        return request.getSession();
+        return request.getSession(false);
     }
 
     @Override
@@ -142,4 +142,6 @@ class CDIWebContext implements IWebContext {
             this.variables.putAll(variables);
         }
     }
+
+
 }

--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
@@ -18,8 +18,6 @@ package org.mvcspec.ozark.ext.thymeleaf;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.IWebContext;
-import org.thymeleaf.context.WebContext;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.BeanManager;
@@ -74,4 +72,5 @@ public class ThymeleafViewEngine extends ViewEngineBase {
             throw new ViewEngineException(e);
         }
     }
+
 }

--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
@@ -66,11 +66,13 @@ public class ThymeleafViewEngine extends ViewEngineBase {
             model.put("request", request);
             ctx.setVariables(model);
 
-            engine.process(resolveView(context), ctx, response.getWriter());
-
-        } catch (IOException e) {
-            throw new ViewEngineException(e);
-        }
-    }
+			try {engine.process(resolveView(context), ctx, response.getWriter());response.flushBuffer();
+            } finally {
+			    ctx.close();
+}
+		} catch (IOException e) {
+			throw new ViewEngineException(e);
+		}
+	}
 
 }

--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
@@ -35,6 +35,7 @@ import java.util.Map;
  * Class Thymeleaf ViewEngine.
  *
  * @author Rodrigo Turini
+ * @author Gregor Tudan
  */
 @ApplicationScoped
 public class ThymeleafViewEngine extends ViewEngineBase {
@@ -66,13 +67,15 @@ public class ThymeleafViewEngine extends ViewEngineBase {
             model.put("request", request);
             ctx.setVariables(model);
 
-			try {engine.process(resolveView(context), ctx, response.getWriter());response.flushBuffer();
+            try {
+                engine.process(resolveView(context), ctx, response.getWriter());
+                response.flushBuffer();
             } finally {
-			    ctx.close();
-}
-		} catch (IOException e) {
-			throw new ViewEngineException(e);
-		}
-	}
+                ctx.close();
+            }
+        } catch (IOException e) {
+            throw new ViewEngineException(e);
+        }
+    }
 
 }

--- a/test/thymeleaf/src/main/java/org/mvcspec/ozark/test/thymeleaf/Greeting.java
+++ b/test/thymeleaf/src/main/java/org/mvcspec/ozark/test/thymeleaf/Greeting.java
@@ -15,30 +15,23 @@
  */
 package org.mvcspec.ozark.test.thymeleaf;
 
-import javax.inject.Inject;
-import javax.mvc.Controller;
-import javax.mvc.View;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.faces.bean.RequestScoped;
+import javax.inject.Named;
 
 /**
- * HelloController test.
- *
- * @author Rodrigo Turini
+ * @author Gregor Tudan
  */
-@Path("hello")
-public class HelloController {
+@RequestScoped
+@Named("greeting")
+public class Greeting {
 
-    @Inject
-    private Greeting greeting;
+    private String user;
 
-    @GET
-    @Controller
-    @Produces("text/html")
-    @View("hello.html")
-    public void hello(@QueryParam("user") String user) {
-        greeting.setUser(user);
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
     }
 }

--- a/test/thymeleaf/src/main/java/org/mvcspec/ozark/test/thymeleaf/Greeting.java
+++ b/test/thymeleaf/src/main/java/org/mvcspec/ozark/test/thymeleaf/Greeting.java
@@ -15,7 +15,7 @@
  */
 package org.mvcspec.ozark.test.thymeleaf;
 
-import javax.faces.bean.RequestScoped;
+import javax.enterprise.context.RequestScoped;
 import javax.inject.Named;
 
 /**

--- a/test/thymeleaf/src/main/webapp/WEB-INF/views/hello.html
+++ b/test/thymeleaf/src/main/webapp/WEB-INF/views/hello.html
@@ -1,10 +1,10 @@
-<html>
+<html  xmlns:th="http://www.thymeleaf.org">
     <head>
       <title>Hello</title>
       <link rel="stylesheet" type="text/css" th:href="@{~{cp}/ozark.css(cp=${request.contextPath})}" />
     </head>
     <body>
-      <h1>Hello <span th:text="${user}"/>!</h1>
+      <h1>Hello <span th:text="${greeting.user}"/>!</h1>
     </body>
 </html>
 


### PR DESCRIPTION
This adds support for `@Named`-Annotated beans in Thymeleaf.
At first I tried extending the WebContext, but that doesn't work as most of it's methods are final.

The Context enumerates all named beans upon constructions, which should be a fairly cheap operation. Initialization is delayed until the reference is actually used in the template. The original idea for this came from https://github.com/inbuss/thymeleaf-cdi, so @inbuss should get the credit for it. 

About testing: I haven't seen any test in the ext package, so I'm not sure how to approach this. Do you have any plans for this?

Closes #64 