### PR TITLE
Jtwig-ViewEngine.

### DIFF
--- a/ext/jtwig/pom.xml
+++ b/ext/jtwig/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mvc-spec.ozark.ext</groupId>
+        <artifactId>ozark-parent-ext</artifactId>
+        <version>1.0.0-m04-SNAPSHOT</version>
+    </parent>
+    <artifactId>ozark-jtwig</artifactId>
+    <packaging>jar</packaging>
+	<name>Ozark Jtwig Extension</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.jtwig</groupId>
+            <artifactId>jtwig-web</artifactId>
+            <version>5.87.0.RELEASE</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/ext/jtwig/src/main/java/org/mvcspec/ozark/ext/jtwig/JtwigViewEngine.java
+++ b/ext/jtwig/src/main/java/org/mvcspec/ozark/ext/jtwig/JtwigViewEngine.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.ext.jtwig;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.mvc.engine.ViewEngineContext;
+import javax.mvc.engine.ViewEngineException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jtwig.web.servlet.JtwigRenderer;
+import org.mvcspec.ozark.engine.ViewEngineBase;
+
+/**
+ * @author Daniel Dias
+ */
+@ApplicationScoped
+public class JtwigViewEngine extends ViewEngineBase {
+
+    private JtwigRenderer jtwigRenderer;
+
+    @PostConstruct
+    public void init() {
+        jtwigRenderer = JtwigRenderer.defaultRenderer();
+    }
+
+    public boolean supports(String view) {
+        return view.endsWith(".twig.html") || view.endsWith(".twig");
+	}
+
+    public void processView(ViewEngineContext context) throws ViewEngineException {
+
+        try {
+
+            Map<String, Object> model = new HashMap<>(context.getModels());
+            model.put("request", context.getRequest(HttpServletRequest.class));
+
+            HttpServletRequest request = context.getRequest(HttpServletRequest.class);
+            HttpServletResponse response = context.getResponse(HttpServletResponse.class);
+
+            jtwigRenderer.dispatcherFor(resolveView(context)).with(model).render(request,response);
+
+        } catch (ServletException | IOException e) {
+            throw new ViewEngineException(e);
+		}
+    }
+}

--- a/ext/jtwig/src/main/resources/META-INF/beans.xml
+++ b/ext/jtwig/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/ext/pom.xml
+++ b/ext/pom.xml
@@ -43,6 +43,7 @@
         <module>velocity</module>
         <module>pebble</module>
         <module>groovy</module>
+        <module>jtwig</module>
     </modules>
 
     <dependencies>

--- a/test/jtwig/pom.xml
+++ b/test/jtwig/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.mvc-spec.ozark.test</groupId>
+        <artifactId>ozark-parent-test</artifactId>
+        <version>1.0.0-m04-SNAPSHOT</version>
+    </parent>
+    <artifactId>jtwig</artifactId>
+    <packaging>war</packaging>
+    <name>Ozark Jtwig Tests</name>
+    <build>
+        <finalName>test-jtwig</finalName>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.mvc-spec.ozark.ext</groupId>
+            <artifactId>ozark-jtwig</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test/jtwig/src/main/java/org/mvcspec/ozark/test/jtwig/HelloController.java
+++ b/test/jtwig/src/main/java/org/mvcspec/ozark/test/jtwig/HelloController.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.test.jtwig;
+
+import javax.inject.Inject;
+import javax.mvc.Controller;
+import javax.mvc.Models;
+import javax.mvc.View;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+/**
+ * HelloController test.
+ *
+ * @author Daniel Dias
+ */
+@Path("hello")
+public class HelloController {
+
+    @Inject
+    private Models models;
+
+    @GET
+    @Controller
+    @View("hello.twig.html")
+    public void hello(@QueryParam("user") String user) {
+        models.put("user", user);
+    }
+}

--- a/test/jtwig/src/main/java/org/mvcspec/ozark/test/jtwig/MyApplication.java
+++ b/test/jtwig/src/main/java/org/mvcspec/ozark/test/jtwig/MyApplication.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.test.jtwig;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Class MyApplication.
+ *
+ * @author Daniel Dias
+ */
+@ApplicationPath("resources")
+public class MyApplication extends Application {
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        return Collections.singleton(HelloController.class);
+    }
+}

--- a/test/jtwig/src/main/webapp/WEB-INF/beans.xml
+++ b/test/jtwig/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>

--- a/test/jtwig/src/main/webapp/WEB-INF/views/hello.twig.html
+++ b/test/jtwig/src/main/webapp/WEB-INF/views/hello.twig.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>Hello</title>
+    <link rel="stylesheet" type="text/css" href="{{request.contextPath}}/ozark.css"/>
+</head>
+<body>
+    <h1>Hello {{ user }}</h1>
+</body>
+</html>

--- a/test/jtwig/src/main/webapp/index.html
+++ b/test/jtwig/src/main/webapp/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Hello Controller using Jtwig</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" type="text/css" href="ozark.css">
+</head>
+<body>
+<h1>Hello Controller using Jtwig</h1>
+<ul>
+    <li><a href="resources/hello?user=mvc">resources/hello?user=mvc</a>
+</ul>
+<br/>
+<a class="source" href="https://github.com/mvc-spec/ozark/blob/master/test/jtwig/src/main/java/org/mvcspec/ozark/test/jtwig/HelloController.java">Source Code</a>
+</body>
+</html>

--- a/test/jtwig/src/main/webapp/ozark.css
+++ b/test/jtwig/src/main/webapp/ozark.css
@@ -1,0 +1,78 @@
+h1 {
+    color: steelblue;
+    font-size: 30px;
+}
+
+h2 {
+    color: steelblue;
+    font-size: 24px;
+    margin-top: 20px;
+}
+
+input {
+    width: 200px;
+    display: block;
+    border: 1px solid #999;
+    height: 25px;
+    margin-bottom: 5px;
+}
+
+input[type=submit] {
+    width: 150px;
+    padding: 5px 5px;
+    background: steelblue;
+    color: white;
+    border: 0 none;
+    cursor: pointer;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    margin-top: 15px;
+}
+
+.source {
+    width: 150px;
+    padding: 8px 8px 8px 8px;
+    background: steelblue;
+    color: white;
+    border: 0 none;
+    cursor: pointer;
+    border-radius: 5px;
+    margin-bottom: 15px;
+    margin-top: 15px;
+}
+
+.table {
+    width: 70%;
+    border-collapse: collapse;
+    color: white;
+}
+
+.table td {
+    padding: 7px;
+}
+
+.table th {
+    background: steelblue;
+    color: white;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    text-align: left;
+    padding-left: 5px;
+    font-size: 125%;
+}
+
+.table tr {
+    background: steelblue;
+}
+
+.table tr:nth-child(odd) {
+    background: steelblue;
+}
+
+.table tr:nth-child(even) {
+    background: lightsteelblue;
+}
+
+.table a {
+    color: white;
+}

--- a/test/jtwig/src/test/java/org/mvcspec/ozark/test/jtwig/JtwigIT.java
+++ b/test/jtwig/src/test/java/org/mvcspec/ozark/test/jtwig/JtwigIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 Ivar Grimstad (ivar.grimstad@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mvcspec.ozark.test.jtwig;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Iterator;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+
+/**
+ * Unit test for simple App.
+ */
+public class JtwigIT { 
+
+    private String webUrl;
+    private WebClient webClient;
+
+    @Before
+    public void setUp() {
+        webUrl = System.getProperty("integration.url");
+        webClient = new WebClient();
+    }
+
+    @After
+    public void tearDown() {
+        webClient.closeAllWindows();
+    }
+
+    @Test
+    public void testView1() throws Exception {
+        final HtmlPage page = webClient.getPage(webUrl + "resources/hello?user=mvc");
+        final Iterator<HtmlElement> it = page.getDocumentElement().getHtmlElementsByTagName("h1").iterator();
+        assertEquals("Hello mvc", it.next().asText().trim());
+    }
+}

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -86,6 +86,7 @@
         <module>uri-builder</module>
         <module>jetbrick</module>
         <module>groovy</module>
+        <module>jtwig</module>
     </modules>
     <profiles>
         <profile>


### PR DESCRIPTION
-  add a new View Engine -> [Jtwig](http://jtwig.org/)

Jtwig is a template engine for Java based on Twig for PHP, which is also based on Django template engine (Python).

[doc - reference](http://jtwig.org/documentation/reference)

license Apache . 