### PR TITLE
Fixed contextPath reference in test JSP files

### DIFF
--- a/test/annotations/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/annotations/src/main/webapp/WEB-INF/views/error.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Error</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Error</h1>

--- a/test/annotations/src/main/webapp/WEB-INF/views/success.jsp
+++ b/test/annotations/src/main/webapp/WEB-INF/views/success.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Success</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Success</h1>

--- a/test/book-cdi/src/main/webapp/WEB-INF/views/book.jsp
+++ b/test/book-cdi/src/main/webapp/WEB-INF/views/book.jsp
@@ -3,7 +3,7 @@
 <html>
     <head>
         <title>Book Information</title>
-        <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css">
+        <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css">
     </head>
     <body>
     <h1>Book Information</h1>

--- a/test/book-models/src/main/webapp/WEB-INF/views/book.jsp
+++ b/test/book-models/src/main/webapp/WEB-INF/views/book.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Book Information</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Book Information</h1>

--- a/test/conversation/src/main/webapp/WEB-INF/views/start.jsp
+++ b/test/conversation/src/main/webapp/WEB-INF/views/start.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Starting Conversation</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Starting Conversation</h1>

--- a/test/conversation/src/main/webapp/WEB-INF/views/stop.jsp
+++ b/test/conversation/src/main/webapp/WEB-INF/views/stop.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Stopping Conversation</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Stopping Conversation</h1>

--- a/test/conversation/src/main/webapp/WEB-INF/views/tellme.jsp
+++ b/test/conversation/src/main/webapp/WEB-INF/views/tellme.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>In Conversation</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>In Conversation</h1>

--- a/test/csrf-property/src/main/webapp/WEB-INF/views/csrf.jsp
+++ b/test/csrf-property/src/main/webapp/WEB-INF/views/csrf.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection Test</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection Test</h1>

--- a/test/csrf-property/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/csrf-property/src/main/webapp/WEB-INF/views/error.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection Error</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection Failed</h1>

--- a/test/csrf-property/src/main/webapp/WEB-INF/views/ok.jsp
+++ b/test/csrf-property/src/main/webapp/WEB-INF/views/ok.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection OK</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection OK</h1>

--- a/test/csrf/src/main/webapp/WEB-INF/views/csrf.jsp
+++ b/test/csrf/src/main/webapp/WEB-INF/views/csrf.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection Test</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection Test</h1>

--- a/test/csrf/src/main/webapp/WEB-INF/views/ok.jsp
+++ b/test/csrf/src/main/webapp/WEB-INF/views/ok.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>CSRF Protection OK</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>CSRF Protection OK</h1>

--- a/test/events/src/main/webapp/WEB-INF/views/event.jsp
+++ b/test/events/src/main/webapp/WEB-INF/views/event.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>MVC Events</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Event Information</h1>

--- a/test/exceptions/src/main/webapp/WEB-INF/views/bye.jsp
+++ b/test/exceptions/src/main/webapp/WEB-INF/views/bye.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Bye World</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Bye World</h1>

--- a/test/exceptions/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/exceptions/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>

--- a/test/locale/src/main/webapp/WEB-INF/views/locale.jsp
+++ b/test/locale/src/main/webapp/WEB-INF/views/locale.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
     <title>Request Locale</title>
 </head>
 <body>

--- a/test/mvc/src/main/webapp/WEB-INF/views/mvc.jsp
+++ b/test/mvc/src/main/webapp/WEB-INF/views/mvc.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Mvc Test</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Mvc Test</h1>

--- a/test/produces/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/produces/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>

--- a/test/redirect/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/redirect/src/main/webapp/WEB-INF/views/error.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Redirect Event not reported!</h1>

--- a/test/redirect/src/main/webapp/WEB-INF/views/redirect.jsp
+++ b/test/redirect/src/main/webapp/WEB-INF/views/redirect.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
     <h1>Redirect Works!</h1>

--- a/test/redirectScope/src/main/webapp/WEB-INF/views/redirect.jsp
+++ b/test/redirectScope/src/main/webapp/WEB-INF/views/redirect.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css">
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css">
 </head>
 <body>
     <h1>Redirect Works!</h1>

--- a/test/redirectScope2/src/main/webapp/WEB-INF/views/redirect.jsp
+++ b/test/redirectScope2/src/main/webapp/WEB-INF/views/redirect.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Redirect</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css">
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css">
 </head>
 <body>
     <h1>Redirect Works!</h1>

--- a/test/returns/src/main/webapp/WEB-INF/views/bye.jsp
+++ b/test/returns/src/main/webapp/WEB-INF/views/bye.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Bye World</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Bye World</h1>

--- a/test/returns/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/returns/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>

--- a/test/uri-builder/src/main/webapp/WEB-INF/views/uri-builder.jsp
+++ b/test/uri-builder/src/main/webapp/WEB-INF/views/uri-builder.jsp
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <title>MvcUriBuilder examples</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <div class="container">

--- a/test/validation-i18n/src/main/webapp/WEB-INF/views/form.jsp
+++ b/test/validation-i18n/src/main/webapp/WEB-INF/views/form.jsp
@@ -3,7 +3,7 @@
 <!doctype html>
 <html>
     <head>
-        <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+        <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
         <title>Validation</title>
     </head>
     <body>

--- a/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/binderror.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
     <title>Form Binding Error</title>
 </head>
 <body>

--- a/test/validation/src/main/webapp/WEB-INF/views/data.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/data.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
     <title>Form Validation</title>
 </head>
 <body>

--- a/test/validation/src/main/webapp/WEB-INF/views/error.jsp
+++ b/test/validation/src/main/webapp/WEB-INF/views/error.jsp
@@ -2,7 +2,7 @@
 <!doctype html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
     <title>Form Validation</title>
 </head>
 <body>

--- a/test/view-annotation/src/main/webapp/WEB-INF/views/bye.jsp
+++ b/test/view-annotation/src/main/webapp/WEB-INF/views/bye.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Bye World</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Bye World</h1>

--- a/test/view-annotation/src/main/webapp/WEB-INF/views/hello.jsp
+++ b/test/view-annotation/src/main/webapp/WEB-INF/views/hello.jsp
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Hello World</title>
-    <link rel="stylesheet" type="text/css" href="${request.contextPath}/ozark.css"/>
+    <link rel="stylesheet" type="text/css" href="${pageContext.request.contextPath}/ozark.css"/>
 </head>
 <body>
 <h1>Hello World</h1>


### PR DESCRIPTION
`${request.contextPath}` doesn't work for JSPs and results in 404 errors when running the tests. We should use `${pageContext.request.contextPath}` instead.