### PR TITLE
Updated Ozark regarding new ViewEngine constants

### DIFF
--- a/core/src/main/java/org/mvcspec/ozark/engine/FaceletsViewEngine.java
+++ b/core/src/main/java/org/mvcspec/ozark/engine/FaceletsViewEngine.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * @author Santiago Pericas-Geertsen
  * @see ViewEngineBase#resolveView(javax.mvc.engine.ViewEngineContext)
  */
-@Priority(ViewEngine.PRIORITY_DEFAULT)
+@Priority(ViewEngine.PRIORITY_BUILTIN)
 public class FaceletsViewEngine extends ServletViewEngine {
 
     /**

--- a/core/src/main/java/org/mvcspec/ozark/engine/JspViewEngine.java
+++ b/core/src/main/java/org/mvcspec/ozark/engine/JspViewEngine.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  * @author Santiago Pericas-Geertsen
  * @see ViewEngineBase#resolveView(javax.mvc.engine.ViewEngineContext)
  */
-@Priority(ViewEngine.PRIORITY_DEFAULT)
+@Priority(ViewEngine.PRIORITY_BUILTIN)
 public class JspViewEngine extends ServletViewEngine {
 
     /**

--- a/core/src/main/java/org/mvcspec/ozark/engine/ViewEngineFinder.java
+++ b/core/src/main/java/org/mvcspec/ozark/engine/ViewEngineFinder.java
@@ -84,9 +84,9 @@ public class ViewEngineFinder {
                 engine = candidates.stream().max(
                         (e1, e2) -> {
                             final Priority p1 = getAnnotation(e1.getClass(), Priority.class);
-                            final int v1 = p1 != null ? p1.value() : ViewEngine.PRIORITY_DEFAULT;
+                            final int v1 = p1 != null ? p1.value() : ViewEngine.PRIORITY_APPLICATION;
                             final Priority p2 = getAnnotation(e2.getClass(), Priority.class);
-                            final int v2 = p2 != null ? p2.value() : ViewEngine.PRIORITY_DEFAULT;
+                            final int v2 = p2 != null ? p2.value() : ViewEngine.PRIORITY_APPLICATION;
                             return v1 - v2;
                         });
                 // Update cache

--- a/ext/asciidoc/src/main/java/org/mvcspec/ozark/ext/asciidoc/AsciiDocViewEngine.java
+++ b/ext/asciidoc/src/main/java/org/mvcspec/ozark/ext/asciidoc/AsciiDocViewEngine.java
@@ -20,8 +20,10 @@ import org.asciidoctor.Asciidoctor.Factory;
 import org.asciidoctor.Options;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
@@ -40,6 +42,7 @@ import java.util.HashMap;
  * @author Ricardo Arguello
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class AsciiDocViewEngine extends ViewEngineBase {
 
     private final Asciidoctor asciidoctor;

--- a/ext/freemarker/src/main/java/org/mvcspec/ozark/ext/freemarker/FreemarkerViewEngine.java
+++ b/ext/freemarker/src/main/java/org/mvcspec/ozark/ext/freemarker/FreemarkerViewEngine.java
@@ -21,8 +21,10 @@ import freemarker.template.TemplateException;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.http.HttpServletRequest;
@@ -39,6 +41,7 @@ import java.util.Map;
  * @author Santiago Pericas-Geertsen
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class FreemarkerViewEngine extends ViewEngineBase {
 
     @Inject

--- a/ext/groovy/src/main/java/org/mvcspec/ozark/ext/groovy/GroovyViewEngine.java
+++ b/ext/groovy/src/main/java/org/mvcspec/ozark/ext/groovy/GroovyViewEngine.java
@@ -26,8 +26,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
@@ -45,6 +47,7 @@ import groovy.text.markup.MarkupTemplateEngine;
  * @author Daniel Dias
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class GroovyViewEngine extends ViewEngineBase {
 
     @Inject

--- a/ext/handlebars/src/main/java/org/mvcspec/ozark/ext/handlebars/HandlebarsViewEngine.java
+++ b/ext/handlebars/src/main/java/org/mvcspec/ozark/ext/handlebars/HandlebarsViewEngine.java
@@ -20,8 +20,10 @@ import com.github.jknack.handlebars.Template;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
@@ -43,6 +45,7 @@ import java.util.stream.Collectors;
  * @author Rahman Usta
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class HandlebarsViewEngine extends ViewEngineBase {
 
     @Inject

--- a/ext/jade/src/main/java/org/mvcspec/ozark/ext/jade/JadeViewEngine.java
+++ b/ext/jade/src/main/java/org/mvcspec/ozark/ext/jade/JadeViewEngine.java
@@ -21,8 +21,10 @@ import de.neuland.jade4j.template.JadeTemplate;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.http.HttpServletRequest;
@@ -41,6 +43,7 @@ import java.util.Map;
  * @see <a href="https://github.com/neuland/jade4j">Jade4J</a>
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class JadeViewEngine extends ViewEngineBase {
 
     @Inject

--- a/ext/jetbrick/src/main/java/org/mvcspec/ozark/ext/jetbrick/JetbrickViewEngine.java
+++ b/ext/jetbrick/src/main/java/org/mvcspec/ozark/ext/jetbrick/JetbrickViewEngine.java
@@ -22,8 +22,10 @@ import jetbrick.template.web.JetWebEngine;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
@@ -39,6 +41,7 @@ import java.util.Map;
  * @author Daniel Dias
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class JetbrickViewEngine extends ViewEngineBase {
 
     private JetEngine jetEngine;

--- a/ext/jsr223/src/main/java/org/mvcspec/ozark/ext/jsr223/Jsr223ViewEngine.java
+++ b/ext/jsr223/src/main/java/org/mvcspec/ozark/ext/jsr223/Jsr223ViewEngine.java
@@ -23,8 +23,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.script.Bindings;
@@ -39,6 +41,7 @@ import javax.servlet.ServletContext;
  * @author Manfred Riem (manfred.riem@oracle.com)
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class Jsr223ViewEngine extends ViewEngineBase {
 
     /**

--- a/ext/jtwig/src/main/java/org/mvcspec/ozark/ext/jtwig/JtwigViewEngine.java
+++ b/ext/jtwig/src/main/java/org/mvcspec/ozark/ext/jtwig/JtwigViewEngine.java
@@ -20,7 +20,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletException;
@@ -34,6 +36,7 @@ import org.mvcspec.ozark.engine.ViewEngineBase;
  * @author Daniel Dias
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class JtwigViewEngine extends ViewEngineBase {
 
     private JtwigRenderer jtwigRenderer;

--- a/ext/mustache/src/main/java/org/mvcspec/ozark/ext/mustache/MustacheViewEngine.java
+++ b/ext/mustache/src/main/java/org/mvcspec/ozark/ext/mustache/MustacheViewEngine.java
@@ -20,8 +20,10 @@ import com.github.mustachejava.MustacheFactory;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.http.HttpServletRequest;
@@ -38,6 +40,7 @@ import java.util.Map;
  * @author Rodrigo Turini
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class MustacheViewEngine extends ViewEngineBase {
 
     @Inject

--- a/ext/pebble/src/main/java/org/mvcspec/ozark/ext/pebble/PebbleViewEngine.java
+++ b/ext/pebble/src/main/java/org/mvcspec/ozark/ext/pebble/PebbleViewEngine.java
@@ -20,7 +20,9 @@ import com.mitchellbosecke.pebble.error.PebbleException;
 import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import java.io.IOException;
@@ -38,6 +40,7 @@ import org.mvcspec.ozark.engine.ViewEngineConfig;
  * @see <a href="http://www.mitchellbosecke.com/pebble/home">Pebble</a>
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class PebbleViewEngine extends ViewEngineBase {
 
   private PebbleEngine pebbleEngine;

--- a/ext/stringtemplate/src/main/java/org/mvcspec/ozark/ext/stringtemplate/StringTemplateViewEngine.java
+++ b/ext/stringtemplate/src/main/java/org/mvcspec/ozark/ext/stringtemplate/StringTemplateViewEngine.java
@@ -18,6 +18,7 @@ package org.mvcspec.ozark.ext.stringtemplate;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.stringtemplate.v4.*;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.mvc.engine.*;
@@ -36,6 +37,7 @@ import static java.util.regex.Pattern.compile;
  * @author Rodrigo Turini
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class StringTemplateViewEngine extends ViewEngineBase {
 
 	@Inject

--- a/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
+++ b/ext/thymeleaf/src/main/java/org/mvcspec/ozark/ext/thymeleaf/ThymeleafViewEngine.java
@@ -19,9 +19,11 @@ import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 import org.thymeleaf.TemplateEngine;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.ServletContext;
@@ -38,6 +40,7 @@ import java.util.Map;
  * @author Gregor Tudan
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class ThymeleafViewEngine extends ViewEngineBase {
 
     @Inject

--- a/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/VelocityViewEngine.java
+++ b/ext/velocity/src/main/java/org/mvcspec/ozark/ext/velocity/VelocityViewEngine.java
@@ -21,8 +21,10 @@ import org.apache.velocity.app.VelocityEngine;
 import org.mvcspec.ozark.engine.ViewEngineBase;
 import org.mvcspec.ozark.engine.ViewEngineConfig;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.mvc.engine.ViewEngine;
 import javax.mvc.engine.ViewEngineContext;
 import javax.mvc.engine.ViewEngineException;
 import javax.servlet.http.HttpServletRequest;
@@ -39,6 +41,7 @@ import java.util.Map;
  * @author Rodrigo Turini
  */
 @ApplicationScoped
+@Priority(ViewEngine.PRIORITY_FRAMEWORK)
 public class VelocityViewEngine extends ViewEngineBase {
 
     @Inject


### PR DESCRIPTION
This PR contains the required changes for Ozark to support the new `ViewEngine` constants. It contains the following changes.

 * Use PRIORITY_BUILTIN for the default view engines
 * Use PRIORITY_FRAMEWORK for all extension view engines
 * Assume PRIORITY_APPLICATION if no `@Priority` annotation is found.

Please do not merge this yet, because we have to wait for mvc-spec/mvc-spec#191 to get merged before.