### PR TITLE
update for Wildfly-14

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 GLASSFISH_URL="http://download.oracle.com/glassfish/5.0.1/nightly/latest-web.zip"
-WILDFLY_URL="http://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final.tar.gz"
+WILDFLY_URL="http://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final.tar.gz"
 LIBERTY_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/18.0.0.2/wlp-webProfile7-18.0.0.2.zip"
 
 if [ "${1}" == "glassfish-bundled" ]; then
@@ -48,7 +48,7 @@ elif [ "${1}" == "tck-wildfly" ]; then
   curl -s -o wildfly.tgz "${WILDFLY_URL}"
   tar -xzf wildfly.tgz
   mvn -B -V -DskipTests clean install
-  LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=wildfly.pid ./wildfly-13.0.0.Final/bin/standalone.sh -Dee8.preview.mode=true > wildfly.log 2>&1 &
+  LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=wildfly.pid ./wildfly-14.0.0.Final/bin/standalone.sh > wildfly.log 2>&1 &
   sleep 30
   pushd tck
   mvn -B -V -Dtck-env=wildfly verify


### PR DESCRIPTION
upgrade to the latest version of Wildfly with full support for Java EE 8.

http://wildfly.org/news/2018/08/30/WildFly14-Final-Released/