### PR TITLE
Updated server versions for integration tests

### DIFF
--- a/.travis/tests.sh
+++ b/.travis/tests.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-GLASSFISH_URL="http://download.oracle.com/glassfish/5.0.1/nightly/latest-web.zip"
-WILDFLY_URL="http://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final.tar.gz"
-LIBERTY_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/18.0.0.2/wlp-webProfile7-18.0.0.2.zip"
+GLASSFISH_URL="https://repo1.maven.org/maven2/org/glassfish/main/distributions/web/5.1.0-RC1/web-5.1.0-RC1.zip"
+WILDFLY_URL="http://download.jboss.org/wildfly/14.0.1.Final/wildfly-14.0.1.Final.tar.gz"
+LIBERTY_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/18.0.0.3/wlp-webProfile7-18.0.0.3.zip"
 
 if [ "${1}" == "glassfish-bundled" ]; then
 
@@ -48,7 +48,7 @@ elif [ "${1}" == "tck-wildfly" ]; then
   curl -s -o wildfly.tgz "${WILDFLY_URL}"
   tar -xzf wildfly.tgz
   mvn -B -V -DskipTests clean install
-  LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=wildfly.pid ./wildfly-14.0.0.Final/bin/standalone.sh > wildfly.log 2>&1 &
+  LAUNCH_JBOSS_IN_BACKGROUND=1 JBOSS_PIDFILE=wildfly.pid ./wildfly-14.0.1.Final/bin/standalone.sh > wildfly.log 2>&1 &
   sleep 30
   pushd tck
   mvn -B -V -Dtck-env=wildfly verify


### PR DESCRIPTION
This PR contains some updates for the servers we run our tests against:

  * Glassfish 5.0.1 nightly -> Eclipse Glassfish 5.1.0.RC1
  * Wildfly 14.0.0 -> Wildfly 14.0.1
  * Liberty 18.0.0.2 -> Liberty 18.0.0.3 

Let's see if Travis likes it. :-)